### PR TITLE
Added cdi-api dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
     <springframework.version>3.0.6.RELEASE</springframework.version>
     <gwt.version>2.5.0-rc1</gwt.version>
     <weld.version>1.1.7.Final</weld.version>
+    <cdi.version>1.0-SP4</cdi.version>
     <errai.version>2.1.0.Beta1</errai.version>
     <gson.version>1.7.2</gson.version>
     <mvc4g.version>1.0.0-jboss</mvc4g.version>
@@ -2397,6 +2398,11 @@
         <groupId>org.jboss.weld</groupId>
         <artifactId>weld-core</artifactId>
         <version>${weld.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>javax.enterprise</groupId>
+        <artifactId>cdi-api</artifactId>
+        <version>${cdi.version}</version>
       </dependency>
       <dependency>
         <groupId>org.jboss.weld.servlet</groupId>


### PR DESCRIPTION
Guvnor uses classes from cdi-api so it needs an explicit dependency on cdi-api.
