### PR TITLE
Removed javax.persistence:persistence-api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2484,11 +2484,6 @@
         <version>1.3.161</version>
       </dependency>
 
-      <dependency>
-        <groupId>javax.persistence</groupId>
-        <artifactId>persistence-api</artifactId>
-        <version>1.0</version>
-      </dependency>
       <!-- JPA 2 implementation agnostic jar -->
       <dependency>
         <groupId>org.hibernate.javax.persistence</groupId>


### PR DESCRIPTION
Removed javax.persistence:persistence-api after replacing all uses with org.hibernate.javax.persistence:hibernate-jpa-2.0-api.
