### PR TITLE
upgrade solder version to 3.2.0.Final to work on AS 7.1.3/7.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3373,7 +3373,12 @@
       <dependency>
         <groupId>org.jboss.solder</groupId>
         <artifactId>solder-impl</artifactId>
-        <version>3.1.1.Final</version>
+        <version>3.2.0.Final</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.solder</groupId>
+        <artifactId>solder-api</artifactId>
+        <version>3.2.0.Final</version>
       </dependency>
       <dependency>
         <groupId>org.jboss.seam.security</groupId>
@@ -3398,7 +3403,40 @@
         <groupId>org.jboss.seam.persistence</groupId>
         <artifactId>seam-persistence</artifactId>
         <version>3.1.0.Final</version>
+          <exclusions>
+              <exclusion>
+                  <groupId>org.jboss.solder</groupId>
+                  <artifactId>solder-api</artifactId>
+              </exclusion>
+              <exclusion>
+                  <groupId>org.jboss.solder</groupId>
+                  <artifactId>solder-impl</artifactId>
+              </exclusion>
+              <exclusion>
+                  <groupId>org.jboss.solder</groupId>
+                  <artifactId>solder-logging</artifactId>
+              </exclusion>
+          </exclusions>
       </dependency>
+        <dependency>
+            <groupId>org.jboss.seam.transaction</groupId>
+            <artifactId>seam-transaction</artifactId>
+            <version>3.1.0.Final</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jboss.solder</groupId>
+                    <artifactId>solder-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.solder</groupId>
+                    <artifactId>solder-impl</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.solder</groupId>
+                    <artifactId>solder-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
       <dependency>
         <groupId>org.jboss.arquillian</groupId>
         <artifactId>arquillian-bom</artifactId>


### PR DESCRIPTION
there was a bug in solder 3.1.1 that caused NPE on weld startup when running on JBoss AS 7.1.3 (which is EAP 6.0.1.GA) and JBoss AS 7.2

solder issue reported as https://issues.jboss.org/browse/SOLDER-337 and it was resolved in 3.2.0.Final version. Tested on AS 7.1.3 with jbpm console-ng

PR excludes default solder version from seam persistence and seam transaction and declares 3.2.0.Final instead.

for reference error that is thrown when using solder 3.1.1 on AS 7.1.3: http://pastebin.com/Zsv1we42
