### PR TITLE
removed test-jar from maven-source-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -318,7 +318,6 @@
             <execution>
               <goals>
                 <goal>jar</goal>
-                <goal>test-jar</goal>
               </goals>
             </execution>
           </executions>


### PR DESCRIPTION
We can't generate test and master source in same execution, mainly when we will need to generate test-source bundles, because they will have same symbolic-name...
