### PR TITLE
Upgrade Mina to 2.0.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3793,7 +3793,7 @@
       <dependency>
         <groupId>org.apache.mina</groupId>
         <artifactId>mina-core</artifactId>
-        <version>2.0.1</version>
+        <version>2.0.4</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
This aligns to the same version as SwitchYard who upgraded Mina when they upgraded Camel to 2.10
