### PR TITLE
Adding managed dependency in order to build jbpm-console-ng.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1259,6 +1259,17 @@
       </dependency>
       <dependency>
         <groupId>org.jbpm</groupId>
+        <artifactId>jbpm-human-task-services</artifactId>
+        <version>${jbpm.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jbpm</groupId>
+        <artifactId>jbpm-human-task-services</artifactId>
+        <version>${jbpm.version}</version>
+        <classifier>sources</classifier>
+      </dependency>
+      <dependency>
+        <groupId>org.jbpm</groupId>
         <artifactId>jbpm-human-task-core</artifactId>
         <version>${jbpm.version}</version>
         <type>test-jar</type>


### PR DESCRIPTION
Fixing error below by adding dependency to droolsjbpm-parent's dependencyManagement.

[ERROR]     'dependencies.dependency.version' for org.jbpm:jbpm-human-task-services:jar is missing. @ line 38, column 21
