### PR TITLE
Upgrade parent pom to jboss-parent 10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jboss</groupId>
     <artifactId>jboss-parent</artifactId>
-    <version>9</version>
+    <version>10</version>
   </parent>
 
   <groupId>org.drools</groupId>


### PR DESCRIPTION
This is for upgrading droolsjbpm parent's inheriting   jboss-parent 10 , which matches the latest of EAP 6.1.
