### PR TITLE
DROOLS-139: Infinispan based Drools and jBPM persistence

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -902,6 +902,17 @@
       </dependency>
       <dependency>
         <groupId>org.drools</groupId>
+        <artifactId>drools-persistence-infinispan</artifactId>
+        <version>${drools.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.drools</groupId>
+        <artifactId>drools-persistence-infinispan</artifactId>
+        <type>test-jar</type>
+        <version>${drools.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.drools</groupId>
         <artifactId>drools-templates</artifactId>
         <version>${drools.version}</version>
       </dependency>
@@ -3608,6 +3619,18 @@
         <groupId>org.jboss.netty</groupId>
         <artifactId>netty</artifactId>
         <version>3.2.0.Final</version>
+      </dependency>
+
+      <!-- Infinispan -->
+      <dependency>
+        <groupId>org.infinispan</groupId>
+        <artifactId>infinispan-core</artifactId>
+        <version>5.2.5.Final</version>
+      </dependency>
+      <dependency>
+        <groupId>org.infinispan</groupId>
+        <artifactId>infinispan-query</artifactId>
+        <version>5.2.5.Final</version>
       </dependency>
 
       <!-- Weld (Context and Dependency Injection) -->


### PR DESCRIPTION
I’ve worked on an infinispan based persistence scheme for drools objects.
The whole idea is to give both a possibility for Infinispan users to have a way to persist these contents in something different than JPA, as well as to give an example of how to build your own persistence scheme for drools and jbpm objects.
