### PR TITLE
upgrade of bitronix to fit hibernate upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3522,7 +3522,7 @@
       <dependency>
         <groupId>org.codehaus.btm</groupId>
         <artifactId>btm</artifactId>
-        <version>2.1.2</version>
+        <version>3.0.0-SNAPSHOT</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
upgrades bitronix transaction manger to latest version that includes fix for new version of hibernate (starting with 4.2.0 that we currently use)

https://jira.codehaus.org/browse/BTM-126
http://bitronix-transaction-manager.10986.n7.nabble.com/Equality-of-PreparedStatement-td1448.html

unfortunately it looks like it's only on snapshot level and no final 3.0 was released. Anyway I think that we use bitronix mainly for tests so we can stick to snapshot for now, wdyt?
