### PR TITLE
upgrade of war plugin to resolve issues with duplicated jars - snapshot ...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -401,7 +401,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-war-plugin</artifactId>
-          <version>2.3</version>
+          <version>2.4-20130702.002149-509</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
...and timestamped

version of maven-war-plugin has been upgraded to get the fix for duplicated jars collected into WEB-INF/lib, details can be found here: https://jira.codehaus.org/browse/MWAR-296

unfortunately it's timestamped version as 2.4 was not released yet.
