### PR TITLE
Remove duplicit 'org.drools:guvnor-api' from dep. management

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1266,17 +1266,12 @@
         <groupId>org.drools</groupId>
         <artifactId>guvnor-api</artifactId>
         <version>${guvnor.version}</version>
+        <classifier>sources</classifier>
       </dependency>
       <dependency>
         <groupId>org.drools</groupId>
         <artifactId>guvnor-jaxb-entities</artifactId>
         <version>${guvnor.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.drools</groupId>
-        <artifactId>guvnor-api</artifactId>
-        <version>${guvnor.version}</version>
-        <classifier>sources</classifier>
       </dependency>
       <dependency>
         <groupId>org.drools</groupId>


### PR DESCRIPTION
Also move the sources artifact right under the binary one.
