### PR TITLE
Fixing bootstrap scripts

### DIFF
--- a/script/git-all.sh
+++ b/script/git-all.sh
@@ -38,11 +38,11 @@ fi
 
 startDateTime=`date +%s`
 
-cd $droolsjbpmOrganizationDir
+cd "$droolsjbpmOrganizationDir"
 
-for repository in `cat ${scriptDir}/repository-list.txt` ; do
+for repository in `cat "${scriptDir}/repository-list.txt"` ; do
     echo
-    if [ ! -d $droolsjbpmOrganizationDir/$repository ]; then
+    if [ ! -d "$droolsjbpmOrganizationDir/$repository" ]; then
         echo "==============================================================================="
         echo "Missing Repository: $repository. SKIPPING!"
         echo "==============================================================================="

--- a/script/git-checkout-all.sh
+++ b/script/git-checkout-all.sh
@@ -47,11 +47,11 @@ read ok
 
 startDateTime=`date +%s`
 
-cd $droolsjbpmOrganizationDir
+cd "$droolsjbpmOrganizationDir"
 
-for repository in `cat ${scriptDir}/repository-list.txt` ; do
+for repository in `cat "${scriptDir}/repository-list.txt"` ; do
     echo
-    if [ ! -d $droolsjbpmOrganizationDir/$repository ]; then
+    if [ ! -d "$droolsjbpmOrganizationDir/$repository" ]; then
         echo "==============================================================================="
         echo "Missing Repository: $repository. SKIPPING!"
         echo "==============================================================================="

--- a/script/git-clone-others.sh
+++ b/script/git-clone-others.sh
@@ -29,13 +29,13 @@ startDateTime=`date +%s`
 # The gitUrlPrefix differs between committers and anonymous users. Also it differs on forks.
 # Committers on blessed gitUrlPrefix="git@github.com:droolsjbpm/"
 # Anonymous users on blessed gitUrlPrefix="git://github.com/droolsjbpm/"
-cd ${scriptDir}
+cd "${scriptDir}"
 gitUrlPrefix=`git remote -v | grep --regex "^origin.*(fetch)$"`
 gitUrlPrefix=`echo ${gitUrlPrefix} | sed 's/^origin\s*//g' | sed 's/droolsjbpm\-build\-bootstrap\.git.*//g'`
 
-cd $droolsjbpmOrganizationDir
+cd "$droolsjbpmOrganizationDir"
 
-for repository in `cat ${scriptDir}/repository-list.txt` ; do
+for repository in `cat "${scriptDir}/repository-list.txt"` ; do
     echo
     if [ -d $repository ] ; then
         echo "==============================================================================="
@@ -73,7 +73,7 @@ done
 echo
 echo Disk size:
 
-for repository in `cat ${scriptDir}/repository-list.txt` ; do
+for repository in `cat "${scriptDir}/repository-list.txt"` ; do
     du -sh $repository
 done
 

--- a/script/mvn-all.sh
+++ b/script/mvn-all.sh
@@ -38,11 +38,11 @@ fi
 
 startDateTime=`date +%s`
 
-cd $droolsjbpmOrganizationDir
+cd "$droolsjbpmOrganizationDir"
 
-for repository in `cat ${scriptDir}/repository-list.txt` ; do
+for repository in `cat "${scriptDir}/repository-list.txt"` ; do
     echo
-    if [ ! -d $droolsjbpmOrganizationDir/$repository ]; then
+    if [ ! -d "$droolsjbpmOrganizationDir/$repository" ]; then
         echo "==============================================================================="
         echo "Missing Repository: $repository. SKIPPING!"
         echo "==============================================================================="


### PR DESCRIPTION
The scripts git-all.sh, git-checkout-all.sh, git-clone-others.sh and mvn-all.sh fail when the project path contain spaces.

They fail the following way:

javi@default:~/Drools and jBPM$ droolsjbpm-build-bootstrap/script/git-all.sh pull
droolsjbpm-build-bootstrap/script/git-all.sh: línea 41: cd: /home/javi/Drools: No existe el fichero o el directorio
cat: /home/javi/Drools: No existe el fichero o el directorio
cat: and: No existe el fichero o el directorio
cat: jBPM/droolsjbpm-build-bootstrap/script/repository-list.txt: No existe el fichero o el directorio

This code add "" in places where it is needed
