### PR TITLE
drools-bom: fix dtable-xls-editor artifactId

### DIFF
--- a/drools-bom/pom.xml
+++ b/drools-bom/pom.xml
@@ -741,7 +741,7 @@
       </dependency>
       <dependency>
         <groupId>org.drools</groupId>
-        <artifactId>guvnor-dtable-xls-editor-backend</artifactId>
+        <artifactId>drools-wb-dtable-xls-editor-backend</artifactId>
         <version>${guvnor.version}</version>
         <classifier>sources</classifier>
       </dependency>


### PR DESCRIPTION
- seems like a leftover fom moving the dtable editor
  from guvnor to drools-wb
