### PR TITLE
Remove knowledge-internal-api from drools-bom

### DIFF
--- a/drools-bom/pom.xml
+++ b/drools-bom/pom.xml
@@ -58,23 +58,6 @@
         <version>${drools.version}</version>
         <classifier>javadoc</classifier>
       </dependency>
-      <dependency>
-        <groupId>org.drools</groupId>
-        <artifactId>knowledge-internal-api</artifactId>
-        <version>${drools.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.drools</groupId>
-        <artifactId>knowledge-internal-api</artifactId>
-        <version>${drools.version}</version>
-        <classifier>sources</classifier>
-      </dependency>
-      <dependency>
-        <groupId>org.drools</groupId>
-        <artifactId>knowledge-internal-api</artifactId>
-        <version>${drools.version}</version>
-        <classifier>javadoc</classifier>
-      </dependency>
 
       <!-- drools -->
       <dependency>


### PR DESCRIPTION
I believe the knowledge-internal-api is not used anymore in 6.x. Master branch has been apparently cleaned some time ago.
