### PR TITLE
Clean-up version properties in kie-parent-metadata

### DIFF
--- a/kie-parent-with-dependencies/pom.xml
+++ b/kie-parent-with-dependencies/pom.xml
@@ -81,7 +81,7 @@
         <groupId>org.kie</groupId>
         <artifactId>kie-bom</artifactId>
         <type>pom</type>
-        <version>${project.version}</version>
+        <version>${kie.version}</version>
         <scope>import</scope>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -45,10 +45,11 @@
 
   <properties>
     <!-- Internal dependencies -->
-    <drools.version>6.2.0-SNAPSHOT</drools.version>
-    <optaplanner.version>${drools.version}</optaplanner.version>
-    <jbpm.version>6.2.0-SNAPSHOT</jbpm.version>
-    <dashboard-builder.version>6.2.0-SNAPSHOT</dashboard-builder.version>
+    <kie.version>6.2.0-SNAPSHOT</kie.version>
+    <drools.version>${kie.version}</drools.version>
+    <optaplanner.version>${kie.version}</optaplanner.version>
+    <jbpm.version>${kie.version}</jbpm.version>
+    <dashboard-builder.version>${kie.version}</dashboard-builder.version>
     <droolsjbpm-integration.version>${drools.version}</droolsjbpm-integration.version>
     <version.org.uberfire>0.4.2-SNAPSHOT</version.org.uberfire>
     <guvnor.version>${drools.version}</guvnor.version>


### PR DESCRIPTION
- use kie.version property as default for others like drools.version
  and jbpm.version.
- the kie.version is also used for kie-bom to be able to change
  version in submodule without interfering with the version of
  kie-bom (before, the version could not in fact be changed,
  unless the kie-bom was also released with that updated version)
