### PR TITLE
Use secured HTTPS access for JBoss public repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
     <repository>
       <id>jboss-public-repository-group</id>
       <name>JBoss Public Repository Group</name>
-      <url>http://repository.jboss.org/nexus/content/groups/public/</url>
+      <url>https://repository.jboss.org/nexus/content/groups/public/</url>
       <releases>
         <enabled>true</enabled>
         <updatePolicy>never</updatePolicy>
@@ -92,7 +92,7 @@
     <pluginRepository>
       <id>jboss-public-repository-group</id>
       <name>JBoss Public Repository Group</name>
-      <url>http://repository.jboss.org/nexus/content/groups/public/</url>
+      <url>https://repository.jboss.org/nexus/content/groups/public/</url>
       <releases>
         <enabled>true</enabled>
       </releases>


### PR DESCRIPTION
Following the recent buzz around the unsecured access to Maven central, I think it would make sense to use the secured HTTPS access to the JBoss public repo. I guess only thing that could be affected by this is deploying to the JBoss Nexus (be it releases or SNAPSHOTs). I am not aware of any issue that should prevent that, but we should make sure it works before applying the changes.

What do you think? Does this change makes sense for you?

See http://blog.ontoillogical.com/blog/2014/07/28/how-to-take-over-any-java-developer/ or http://blog.sonatype.com/2014/08/https-support-launching-now/ for more info.
