### PR TITLE
kie-parent-metadata: specify version for cargo-maven2-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -262,6 +262,11 @@
           </configuration>
         </plugin>
         <plugin>
+          <groupId>org.codehaus.cargo</groupId>
+          <artifactId>cargo-maven2-plugin</artifactId>
+          <version>1.4.9</version>
+        </plugin>
+        <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-failsafe-plugin</artifactId>
           <version>2.15</version>


### PR DESCRIPTION
Plugin configuration (so far just version) for cargo-plugin that is used by kie-server integration tests.
