### PR TITLE
Add enforcer rule that banns cxf-bundle-jaxrs, weld-se and weld-servlet

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,14 @@
                   <requireMavenVersion>
                     <version>[3.0.5,)</version>
                   </requireMavenVersion>
-                   <!-- <requireUpperBoundDeps/> -->
+                  <!-- <requireUpperBoundDeps/> -->
+                  <bannedDependencies>
+                    <excludes>
+                      <exclude>org.apache.cxf:cxf-bundle-jaxrs</exclude>
+                      <exclude>org.jboss.weld.se:weld-se</exclude>
+                      <exclude>org.jboss.weld.servlet:weld-servlet</exclude>
+                    </excludes>
+                  </bannedDependencies>
                 </rules>
               </configuration>
             </execution>


### PR DESCRIPTION
- these shared (Uber) jars are disrupting the dependency graph as they
  bundle classes from other artifacts. Banning these artifacts seems to
  be the only way to avaoid future problems as not everyone is aware of
  their shadiness and the enforcer rule will make sure the dependencies can't
  be used
- this PR should be merged _after_ https://github.com/droolsjbpm/droolsjbpm-integration/pull/102 otherwise the droolsjbpm-integration will fail
