### PR TITLE
drools-bom: remove legacy deps (no longer used)

### DIFF
--- a/drools-bom/pom.xml
+++ b/drools-bom/pom.xml
@@ -328,28 +328,6 @@
       <!-- droolsjbpm-integration -->
       <dependency>
         <groupId>org.drools</groupId>
-        <artifactId>drools-spring-legacy5</artifactId>
-        <version>${version.org.drools.droolsjbpm-integration}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.drools</groupId>
-        <artifactId>drools-spring-legacy5</artifactId>
-        <version>${version.org.drools.droolsjbpm-integration}</version>
-        <classifier>sources</classifier>
-      </dependency>
-      <dependency>
-        <groupId>org.drools</groupId>
-        <artifactId>drools-camel-legacy5</artifactId>
-        <version>${version.org.drools.droolsjbpm-integration}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.drools</groupId>
-        <artifactId>drools-camel-legacy5</artifactId>
-        <version>${version.org.drools.droolsjbpm-integration}</version>
-        <classifier>sources</classifier>
-      </dependency>
-      <dependency>
-        <groupId>org.drools</groupId>
         <artifactId>drools-camel-server-example</artifactId>
         <type>war</type>
         <version>${version.org.drools.droolsjbpm-integration}</version>


### PR DESCRIPTION
I believe the `drools-spring-legacy5` and `drools-camel-legacy5` are not longer present (or at least I could not find them in droolsjbpm-integration). If that is the case, please merge this also into 6.2.x.
