### PR TITLE
Specifify the Maven Central before the JBoss.org repo to speed up builds

### DIFF
--- a/kie-user-bom-parent/pom.xml
+++ b/kie-user-bom-parent/pom.xml
@@ -58,10 +58,16 @@
   </properties>
 
   <repositories>
+    <!-- Having the <repositories> in this POM is an ugly hack to make sure we can always find
+         the jboss-integration-platform-parent (ip-parent). In most of the cases the ip-parent is available directly from
+         Maven Central. However, when new version gets released it takes up to 24 hours to get it synced into the Maven
+         Central. So in that period the local build of droolsjbpm-build-bootstrap would fail (unless one would
+         locally build the ip-parent from the sources as well, which is not something users should be doing). Configuring the
+         'repository.jboss.org' directly works around this issue. -->
     <repository>
       <!-- Duplicating the Maven Central repository here (as it is already coming from Super POM) makes the build much faster,
            as the Maven Central is now treated as the first (default) repository (because it is before the JBoss.org one).
-           Artifacts with release (fixed) versions are being downloaded primarily from there. Without the central being the
+           Artifacts with release (fixed) versions are being downloaded primarily from central. Without the central being the
            first repository the JBoss.org Nexus would be contacted first and since it is quite slow it slows down the build.
            We use JBoss.org repo only to download our SNAPSHOTs. -->
       <id>central</id>

--- a/kie-user-bom-parent/pom.xml
+++ b/kie-user-bom-parent/pom.xml
@@ -58,6 +58,20 @@
   </properties>
 
   <repositories>
+    <repository>
+      <!-- Duplicating the Maven Central repository here (as it is already coming from Super POM) makes the build much faster,
+           as the Maven Central is now treated as the first (default) repository (because it is before the JBoss.org one).
+           Artifacts with release (fixed) versions are being downloaded primarily from there. Without the central being the
+           first repository the JBoss.org Nexus would be contacted first and since it is quite slow it slows down the build.
+           We use JBoss.org repo only to download our SNAPSHOTs. -->
+      <id>central</id>
+      <name>Central Repository</name>
+      <url>https://repo.maven.apache.org/maven2</url>
+      <layout>default</layout>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
     <!-- Bootstrap repository to locate the parent pom when the parent pom has not been build locally. -->
     <!-- Conventions are described in http://community.jboss.org/wiki/MavenGettingStarted-Developers -->
     <repository>
@@ -74,6 +88,33 @@
       </snapshots>
     </repository>
   </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <!-- Duplicating the Maven Central repository here (as it is already coming from Super POM) makes the build much faster,
+           as the Maven Central is now treated as the first (default) repository (because it is before the JBoss.org one).
+           Artifacts with release (fixed) versions are being downloaded primarily from there. Without the central being the
+           first repository the JBoss.org Nexus would be contacted first and since it is quite slow it slows down the build.
+           We use JBoss.org repo only to download our SNAPSHOTs. -->
+      <id>central</id>
+      <name>Central Repository</name>
+      <url>https://repo.maven.apache.org/maven2</url>
+      <layout>default</layout>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </pluginRepository>
+    <pluginRepository>
+      <id>jboss-public-repository-group</id>
+      <name>JBoss Public Repository Group</name>
+      <url>https://repository.jboss.org/nexus/content/groups/public/</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </pluginRepository>
+  </pluginRepositories>
 
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -201,6 +201,20 @@
   </properties>
 
   <repositories>
+    <repository>
+      <!-- Duplicating the Maven Central repository here (as it is already coming from Super POM) makes the build much faster,
+           as the Maven Central is now treated as the first (default) repository (because it is before the JBoss.org one).
+           Artifacts with release (fixed) versions are being downloaded primarily from there. Without the central being the
+           first repository the JBoss.org Nexus would be contacted first and since it is quite slow it slows down the build.
+           We use JBoss.org repo only to download our SNAPSHOTs. -->
+      <id>central</id>
+      <name>Central Repository</name>
+      <url>https://repo.maven.apache.org/maven2</url>
+      <layout>default</layout>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
     <!-- Bootstrap repository to locate the parent pom when the parent pom has not been build locally. -->
     <!-- Conventions are described in http://community.jboss.org/wiki/MavenGettingStarted-Developers -->
     <repository>
@@ -217,7 +231,22 @@
       </snapshots>
     </repository>
   </repositories>
+
   <pluginRepositories>
+    <pluginRepository>
+      <!-- Duplicating the Maven Central repository here (as it is already coming from Super POM) makes the build much faster,
+           as the Maven Central is now treated as the first (default) repository (because it is before the JBoss.org one).
+           Artifacts with release (fixed) versions are being downloaded primarily from there. Without the central being the
+           first repository the JBoss.org Nexus would be contacted first and since it is quite slow it slows down the build.
+           We use JBoss.org repo only to download our SNAPSHOTs. -->
+      <id>central</id>
+      <name>Central Repository</name>
+      <url>https://repo.maven.apache.org/maven2</url>
+      <layout>default</layout>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </pluginRepository>
     <pluginRepository>
       <id>jboss-public-repository-group</id>
       <name>JBoss Public Repository Group</name>


### PR DESCRIPTION
Testing the build time locally with empty local repo
(`mvn clean install -Dmaven.repo.local=maven-repo`) shows huge
improvement. 8min30s (without this change) vs 1min (with this change)
just for the build-bootstrap repo.

@mbiarnes, @ge0ffrey please take a look at let me know what you think. It definitely is not ideal, but I believe the speed up is worth it.