### PR TITLE
JBPM-5490: Upgrade to lienzo 2.0.287-RELEASE.

### DIFF
--- a/kie-bom/pom.xml
+++ b/kie-bom/pom.xml
@@ -1469,6 +1469,13 @@
 
       <dependency>
         <groupId>org.kie.workbench.stunner</groupId>
+        <artifactId>kie-wb-common-stunner-core-common</artifactId>
+        <version>${version.org.kie}</version>
+        <type>test-jar</type>
+      </dependency>
+
+      <dependency>
+        <groupId>org.kie.workbench.stunner</groupId>
         <artifactId>kie-wb-common-stunner-backend-common</artifactId>
         <version>${version.org.kie}</version>
       </dependency>
@@ -1491,6 +1498,13 @@
         <artifactId>kie-wb-common-stunner-client-common</artifactId>
         <version>${version.org.kie}</version>
         <classifier>sources</classifier>
+      </dependency>
+
+      <dependency>
+        <groupId>org.kie.workbench.stunner</groupId>
+        <artifactId>kie-wb-common-stunner-client-common</artifactId>
+        <version>${version.org.kie}</version>
+        <type>test-jar</type>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,8 @@
     <version.javax.validation>1.0.0.GA</version.javax.validation>
 
     <!-- Lienzo core upgrade required by Stunner. Can be removed once IP BOM is upgraded.-->
-    <version.com.ahome-it.lienzo-core>2.0.286-RELEASE</version.com.ahome-it.lienzo-core>
+    <version.com.ahome-it.lienzo-core>2.0.287-RELEASE</version.com.ahome-it.lienzo-core>
+    <version.com.ahome-it.lienzo-tests>2.0.287-RELEASE</version.com.ahome-it.lienzo-tests>
 
     <!-- CSS parsing library from Apache used by Stunner. -->
     <version.net.sourceforge.cssparser>0.9.21</version.net.sourceforge.cssparser>


### PR DESCRIPTION
Hey @manstis , @psiroky 

This is the upgrade to `lienzo-core` and `lienzo-tests` to version `2.0.287-RELEASE` for our 7.0.x branch. 

A few notes:

- Building only `uberfire` for `1.0.x `branch, the dependency versions resolved for lienzo stuff are a bit old. I dunno how to change this as it depends on a `CR2` IP BOM version already released. Anyway as our KIE-BOM uses the latest version, so the final version resolved for both kie and drools workbenches is fine (latest one),  the builds and webapps are working fine too.
- Once this gets merged, will create same PRs on master and for IP-BOM as well, so I understand all will be fine too.

Thanks!