### PR TITLE
Add a script for an easy way to clean revapi ignores

### DIFF
--- a/script/utils/revapi-clean.sh
+++ b/script/utils/revapi-clean.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# Utility script for removing ignores in revapi-config.json files.
+
+usage ()
+{
+  echo "################################## Revapi clean ##################################"
+  echo "Usage : `basename $0` <latestFinalCommunityVersion> <futureFinalCommunityVersion>"
+  echo "        for example: ./revapi-clean.sh 7.0.0.Final 7.1.0.Final"
+  echo "        OR"
+  echo "        `basename $0` -h for help"
+  echo "##################################################################################"
+  exit
+}
+
+getopts :h opt
+
+if [ "$opt" == "h" ]; then
+    usage
+elif [ "$#" -ne 2 ]; then
+    usage
+else
+    # First, delete ignores
+    find . -iname "revapi-config.json" -exec perl -i -0pe 's/("ignore":.*)\[.*\]/\1\[\]/s' {} \;
+    # Secondly, change versions in the comment
+    find . -iname "revapi-config.json" -exec perl -i -0pe "s/(\"Changes between).*(and the current branch.*when).*(is available)/\1 $1 \2 $2 \3/s" {} \;
+fi


### PR DESCRIPTION
Hi, @psiroky,

I have created a script to simplify revapi ignores cleanup. It works this way:

`revapi-clean.sh <latestFinalCommunityVersion> <futureFinalCommunityVersion>`

For example:
`revapi-clean.sh 7.0.0.Final 7.1.0.Final`

It is sufficient to run it from the root of the repository which contains revapi-config.json files, since it will find such files recursively. In each of these files it will delete ignores and substitute versions in the comment.

This script should be run only on master if the following process is followed, for example:

1. After 7.0.0.Final is released in the community, run the script on master (7.0.x branch is already created) with parameters 7.0.0.Final and 7.1.0.Final. So master is tracking changes on master against 7.0.0.Final, while 7.0.x is tracking changes against 6.5.0.Final as it does now.
2. In the future, 7.1.x branch will be created from master. Revapi still checks 7.1.x against 7.0.0.Final on this branch.
3. Once 7.1.0.Final is created, run the script again with parameters 7.1.0.Final and 7.2.0.Final. So on master revapi now checks master against 7.1.0.Final.

And so on.

I hope it makes sense. On the "numbered" branches we will still check all changes against previous Final version, while on master we will check all changes against the latest Final version.

I recommend to merge this PR only after all PRs regarding revapi-config.json file change are merged.

Thanks,

Marian
