### PR TITLE
Bump latest Final version to 7.0.0 and fix revapi-clean script

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -195,7 +195,7 @@
     <jboss.snapshots.repo.url>https://origin-repository.jboss.org/nexus/content/repositories/snapshots/</jboss.snapshots.repo.url>
 
     <!-- Latest release to be used by api-compatibility-check to check backwards compatibility of the Kie API. -->
-    <version.org.kie.latestFinal.release>6.5.0.Final</version.org.kie.latestFinal.release>
+    <version.org.kie.latestFinal.release>7.0.0.Final</version.org.kie.latestFinal.release>
     <revapi.oldKieVersion>${version.org.kie.latestFinal.release}</revapi.oldKieVersion>
     <revapi.newKieVersion>${project.version}</revapi.newKieVersion>
 

--- a/script/utils/revapi-clean.sh
+++ b/script/utils/revapi-clean.sh
@@ -20,7 +20,7 @@ elif [ "$#" -ne 2 ]; then
     usage
 else
     # First, delete ignores
-    find . -iname "revapi-config.json" -exec perl -i -0pe 's/("ignore":.*)\[.*\]/\1\[\]/s' {} \;
+    find . -iname "revapi-config.json" -exec perl -i -0pe 's/("ignore":.*?)\[.*\]/\1\[\]/s' {} \;
     # Secondly, change versions in the comment
     find . -iname "revapi-config.json" -exec perl -i -0pe "s/(\"Changes between).*(and the current branch.*when).*(is available)/\1 $1 \2 $2 \3/s" {} \;
 fi


### PR DESCRIPTION
Hi, @psiroky,

I have updated revapi configuration and fixed a small bug in revapi-clean script which I encountered when I was cleaning revapi ignores across the repositories. ~~I will put there all PRs which relate to this change.~~

Full PR set:

- kiegroup/droolsjbpm-knowledge#236
- kiegroup/jbpm#859
- kiegroup/droolsjbpm-integration#994
- kiegroup/optaplanner#314
- kiegroup/guvnor#459
- kiegroup/drools#1289

Thanks,

Marian
