### PR TITLE
Add common Pitest configuration for mutation coverage analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,6 +467,29 @@ The check binds to the verify phase and for the plugin to run, the code-coverage
 
 * The coverage report is then generated in ./target/site/jacoco/index.html
 
+Running Pitest mutation coverage analysis
+-----------------------------------------
+
+Mutation coverage is used to measure how good the tests are at making assertions about the tested code.
+It is a good idea to check the mutation coverage of tests added together with any changes, be it a newly developed
+feature or a bug fix. Code coverage is analyzed for free as part of the mutation analysis.
+
+To analyze the complete module:
+
+```shell
+$ mvn verify -Dmutation-coverage
+```
+
+To limit analyzed classes to a sub-package:
+
+```shell
+$ mvn verify -Dmutation-coverage -DtargetClasses=org.drools*
+```
+
+The HTML report will be stored in `local/pit-reports/` directory.
+Currently, it is not possible to get a report aggregated over multiple modules.
+Learn more about using [Pitest](http://pitest.org/quickstart/maven/).
+
 Configuring Maven
 -----------------
 

--- a/pom.xml
+++ b/pom.xml
@@ -1191,6 +1191,31 @@
           <artifactId>kie-maven-plugin</artifactId>
           <version>${version.org.kie}</version>
         </plugin>
+        <plugin>
+          <groupId>org.pitest</groupId>
+          <artifactId>pitest-maven</artifactId>
+          <version>1.2.0</version>
+          <configuration>
+            <reportsDirectory>local/pit-reports</reportsDirectory>
+            <timestampedReports>false</timestampedReports>
+            <timeoutConstant>1000</timeoutConstant>
+            <mutators>
+              <!--
+              <mutator>CONDITIONALS_BOUNDARY</mutator>
+              <mutator>NEGATE_CONDITIONALS</mutator>
+              <mutator>MATH</mutator>
+              <mutator>INCREMENTS</mutator>
+              <mutator>INVERT_NEGS</mutator>
+              <mutator>RETURN_VALS</mutator>
+              <mutator>VOID_METHOD_CALLS</mutator>
+              -->
+              <mutator>DEFAULTS</mutator>
+              <mutator>NON_VOID_METHOD_CALLS</mutator>
+              <mutator>REMOVE_CONDITIONALS</mutator>
+            </mutators>
+            <avoidCallsTo>java.lang.StringBuilder</avoidCallsTo>
+          </configuration>
+        </plugin>
       </plugins>
     </pluginManagement>
 
@@ -1316,6 +1341,32 @@
           <plugin>
             <groupId>org.jacoco</groupId>
             <artifactId>jacoco-maven-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <!-- Mutation coverage disabled by default (use -Dmutation-coverage to activate it) -->
+      <id>mutation-coverage</id>
+      <activation>
+        <property>
+          <name>mutation-coverage</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.pitest</groupId>
+            <artifactId>pitest-maven</artifactId>
+            <executions>
+              <execution>
+                <id>default-pitest</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>mutationCoverage</goal>
+                </goals>
+              </execution>
+            </executions>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
The common Pitest configuration will allow to run mutation coverage analysis in any module having `kie-parent` as its ancestor. This will make the tool available out of the box using a simple Maven invocation, which will be appreciated by QE, and developers might find this useful too.