### PR TITLE
JBPM-4480: Add Swagger to KIE-Server REST API

### DIFF
--- a/kie-bom/pom.xml
+++ b/kie-bom/pom.xml
@@ -225,6 +225,17 @@
       </dependency>
       <dependency>
         <groupId>org.kie.server</groupId>
+        <artifactId>kie-server-services-swagger</artifactId>
+        <version>${version.org.kie}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.kie.server</groupId>
+        <artifactId>kie-server-services-swagger</artifactId>
+        <version>${version.org.kie}</version>
+        <classifier>sources</classifier>
+      </dependency>
+      <dependency>
+        <groupId>org.kie.server</groupId>
         <artifactId>kie-server-jms</artifactId>
         <version>${version.org.kie}</version>
       </dependency>
@@ -319,6 +330,17 @@
       <dependency>
         <groupId>org.kie.server</groupId>
         <artifactId>kie-server-rest-case-mgmt</artifactId>
+        <version>${version.org.kie}</version>
+        <classifier>sources</classifier>
+      </dependency>
+      <dependency>
+        <groupId>org.kie.server</groupId>
+        <artifactId>kie-server-rest-swagger</artifactId>
+        <version>${version.org.kie}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.kie.server</groupId>
+        <artifactId>kie-server-rest-swagger</artifactId>
         <version>${version.org.kie}</version>
         <classifier>sources</classifier>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -2153,7 +2153,7 @@
       
       <dependency>
         <groupId>io.swagger</groupId>
-	<artifactId>swagger-jersey2-jaxrs</artifactId>
+	<artifactId>swagger-core</artifactId>
 	<version>${version.io.swagger}</version>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,7 @@
     <version.org.picketlink>2.6.0.Final</version.org.picketlink>
     <version.com.unboundid>2.3.6</version.com.unboundid>
     <version.com.wordnik.swagger>1.3.10</version.com.wordnik.swagger>
+    <version.io.swagger>1.5.15</version.io.swagger>
     <version.org.jboss.as>7.2.0.Final</version.org.jboss.as>
     <version.org.jboss.byteman>3.0.1</version.org.jboss.byteman>
     <version.org.roboguice>3.0.1</version.org.roboguice>
@@ -2148,6 +2149,22 @@
         <groupId>com.wordnik</groupId>
         <artifactId>swagger-annotations</artifactId>
         <version>${version.com.wordnik.swagger}</version>
+      </dependency>
+      
+      <dependency>
+        <groupId>io.swagger</groupId>
+	<artifactId>swagger-jersey2-jaxrs</artifactId>
+	<version>1.5.15</version>
+      </dependency>
+      <dependency>
+        <groupId>io.swagger</groupId>
+        <artifactId>swagger-jaxrs</artifactId>
+        <version>1.5.15</version>
+      </dependency>
+      <dependency>
+        <groupId>io.swagger</groupId>
+        <artifactId>swagger-annotations</artifactId>
+        <version>1.5.15</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -2154,17 +2154,17 @@
       <dependency>
         <groupId>io.swagger</groupId>
 	<artifactId>swagger-jersey2-jaxrs</artifactId>
-	<version>1.5.15</version>
+	<version>${version.io.swagger}</version>
       </dependency>
       <dependency>
         <groupId>io.swagger</groupId>
         <artifactId>swagger-jaxrs</artifactId>
-        <version>1.5.15</version>
+        <version>${version.io.swagger}</version>
       </dependency>
       <dependency>
         <groupId>io.swagger</groupId>
         <artifactId>swagger-annotations</artifactId>
-        <version>1.5.15</version>
+        <version>${version.io.swagger}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
This is for JBPM-4480: https://issues.jboss.org/browse/JBPM-4480

One additional comment, the POM already contained and old com.wordnik.swagger dependency, but I couldn't really find where that dependency is actually used. If it's not used anywhere, we should remove it. If it is used, we should consider upgrading the dependency to "io.swagger".