### PR TITLE
Remove extra spaces from License instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -829,7 +829,7 @@ Configuring Eclipse
          * you may not use this file except in compliance with the License.
          * You may obtain a copy of the License at
          *
-         *       http://www.apache.org/licenses/LICENSE-2.0
+         *     http://www.apache.org/licenses/LICENSE-2.0
          *
          * Unless required by applicable law or agreed to in writing, software
          * distributed under the License is distributed on an "AS IS" BASIS,
@@ -1137,7 +1137,7 @@ Configuring IntelliJ
             you may not use this file except in compliance with the License.
             You may obtain a copy of the License at
 
-                  http://www.apache.org/licenses/LICENSE-2.0
+                http://www.apache.org/licenses/LICENSE-2.0
 
             Unless required by applicable law or agreed to in writing, software
             distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
According to main [license file](https://github.com/kiegroup/droolsjbpm-build-bootstrap/blob/master/LICENSE-ASL-2.0.txt#L196).