### PR TITLE
AF-540: additional models to support generic data model move from drools to appformer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1642,6 +1642,16 @@
         <artifactId>uberfire-maven-integration</artifactId>
         <version>${version.org.uberfire}</version>
       </dependency>
+      <dependency>
+        <groupId>org.uberfire</groupId>
+        <artifactId>uberfire-project-datamodel-api</artifactId>
+        <version>${version.org.uberfire}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.uberfire</groupId>
+        <artifactId>uberfire-project-datamodel-commons</artifactId>
+        <version>${version.org.uberfire}</version>
+      </dependency>
 
       <dependency>
         <groupId>org.apache.camel</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1634,6 +1634,11 @@
     <dependencies>
       <dependency>
         <groupId>org.uberfire</groupId>
+        <artifactId>uberfire-commons</artifactId>
+        <version>${version.org.uberfire}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.uberfire</groupId>
         <artifactId>uberfire-maven-support</artifactId>
         <version>${version.org.uberfire}</version>
       </dependency>


### PR DESCRIPTION
This is a mandatory step before merging the repos to form AppFormer single repository.

Related PRs:
https://github.com/AppFormer/uberfire/pull/784
https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/487
https://github.com/kiegroup/drools/pull/1397
https://github.com/kiegroup/droolsjbpm-integration/pull/1135
https://github.com/kiegroup/guvnor/pull/484
https://github.com/kiegroup/kie-wb-common/pull/1005
https://github.com/kiegroup/drools-wb/pull/560
https://github.com/kiegroup/optaplanner-wb/pull/205