### PR TITLE
Add branch mapping file

### DIFF
--- a/script/branch-mapping.yaml
+++ b/script/branch-mapping.yaml
@@ -1,0 +1,53 @@
+# Branch mapping for SNAPSHOT projects KIE depends on
+#
+# The entries are in the following format:
+# <kie-branch>:
+#  - [<org.unit>/]<repo>: <branch> -- <org.unit> is optional in case it's equal to the repo name
+master:
+  - errai: master
+  - uberfire: master
+  - dashbuilder: master
+
+7.2.x:
+  - errai: 4.0.x
+  - uberfire: 1.2.x
+  - dashbuilder: 0.8.x
+
+7.1.x:
+  - errai: 4.0.x
+  - uberfire: 1.1.x
+  - dashbuilder: 0.7.x
+
+7.0.x:
+  - errai: 4.0.x
+  - uberfire: 1.0.x
+  - dashbuilder: 0.6.x
+
+6.5.x:
+  - uberfire: 0.9.x
+  - uberfire/uberfire-extensions: 0.9.x
+  - dashbuilder: 0.5.x
+
+6.4.x:
+  - uberfire: 0.8.x
+  - uberfire/uberfire-extensions: 0.8.x
+  - dashbuilder: 0.4.x
+
+6.3.x:
+  - uberfire: 0.7.x
+  - uberfire/uberfire-extensions: 0.7.x
+  - dashbuilder: 0.3.x
+
+6.2.x:
+  - uberfire: 0.5.x
+  - uberfire/uberfire-extensions: 0.5.x
+  - dashbuilder: 0.2.x
+
+6.1.x:
+  - uberfire: 0.4.x
+  - uberfire/uberfire-extensions: 0.4.x
+
+6.0.x:
+  - uberfire: 0.3.x
+  - uberfire/uberfire-extensions: 0.3.x
+


### PR DESCRIPTION
@mbiarnes please take a look. This should make the version upgrades easier. Instead of updating the 
`kie-build-helper-jenkins-plugin` every time, we would just need to update this file. One thing to remember is that we need to make sure the file is valid at all times otherwise bad things would happen :)


[jenkins skip ci]