### PR TITLE
JBPM-5967: Upgrade to lienzo 2.0.291-RELEASE.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,8 +152,8 @@
     <version.javax.validation>1.0.0.GA</version.javax.validation>
 
     <!-- Lienzo core upgrade required by Stunner. Can be removed once IP BOM is upgraded.-->
-    <version.com.ahome-it.lienzo-core>2.0.287-RELEASE</version.com.ahome-it.lienzo-core>
-    <version.com.ahome-it.lienzo-tests>2.0.287-RELEASE</version.com.ahome-it.lienzo-tests>
+    <version.com.ahome-it.lienzo-core>2.0.291-RELEASE</version.com.ahome-it.lienzo-core>
+    <version.com.ahome-it.lienzo-tests>2.0.291-RELEASE</version.com.ahome-it.lienzo-tests>
 
     <!-- CSS parsing library from Apache used by Stunner. -->
     <version.net.sourceforge.cssparser>0.9.21</version.net.sourceforge.cssparser>


### PR DESCRIPTION
Hey @manstis , back-ported [this commit](https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/500) into `7.3.x` as well. 
PS Just creating now the back-port for the commit in `kie-wb-common`, have to be merged together. Adding the PR link in a bit.
Thanks!  