### PR TITLE
RHBRMS-2870 - override of version.org.apache.httpcomponents.httpcore

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,7 @@
 
     <!-- Required to support SNI requests, see RHBRMS-2870 -->
     <version.org.apache.httpcomponents.httpclient>4.5.3</version.org.apache.httpcomponents.httpclient>
+    <version.org.apache.httpcomponents.httpcore>4.4.6</version.org.apache.httpcomponents.httpcore>
 
     <version.org.drools.guvnor-api>5.6.0.Final</version.org.drools.guvnor-api>
     <version.org.jboss.errai>4.0.3-SNAPSHOT</version.org.jboss.errai>


### PR DESCRIPTION
(cherry picked from commit 1b3251f5db803460b55a00bab9f606106833ae03)