### PR TITLE
repository-list: jbpm-console-ng -> jbpm-wb

### DIFF
--- a/script/repository-list.txt
+++ b/script/repository-list.txt
@@ -11,7 +11,7 @@ kie-wb-common
 jbpm-form-modeler
 drools-wb
 jbpm-designer
-jbpm-console-ng
+jbpm-wb
 dashboard-builder
 optaplanner-wb
 jbpm-dashboard


### PR DESCRIPTION
The repo was renamed some time ago and even tough the 'jbpm-console-ng'
still works as redirect, it causes minor issues here and there as the
two names actually differ.

@mbiarnes could you please take a look? Would this break something?