### PR TITLE
changed variable name since old variable name wasn't found

### DIFF
--- a/script/release/kie-copyBinariesToNexus.sh
+++ b/script/release/kie-copyBinariesToNexus.sh
@@ -5,14 +5,14 @@ kieVersion=$(sed -e 's/^[ \t]*//' -e 's/[ \t]*$//' -n -e 's/<version.org.kie>\(.
 
 if [ "$target" == "community" ]; then
    stagingRep=15c58a1abc895b
-   deploy-dir=$WORKSPACE/community-deploy-dir
+   deployDir=$WORKSPACE/community-deploy-dir
 else
    stagingRep=15c3321d12936e
-   deploy-dir=$WORKSPACE/prod-deploy-dir
+   deployDir=$WORKSPACE/prod-deploy-dir
 fi
 
-cd $deploy-dir
+cd $deployDir
 # upload the content to remote staging repo
 mvn -B -e org.sonatype.plugins:nexus-staging-maven-plugin:1.6.5:deploy-staged-repository -DnexusUrl=https://repository.jboss.org/nexus -DserverId=jboss-releases-repository\
- -DrepositoryDirectory=$deploy-dir -DstagingProfileId=$stagingRep -DstagingDescription="kie-$kieVersion" -DstagingProgressTimeoutMinutes=30
+ -DrepositoryDirectory=$deployDir -DstagingProfileId=$stagingRep -DstagingDescription="kie-$kieVersion" -DstagingProgressTimeoutMinutes=30
 

--- a/script/release/kie-deployLocally.sh
+++ b/script/release/kie-deployLocally.sh
@@ -41,15 +41,15 @@ echo target=$target >> kie.properties
 
 # build release branches
 if [ "$target" == "community" ]; then
-   deploy-dir=$WORKSPACE/community-deploy-dir
+   deployDir=$WORKSPACE/community-deploy-dir
    # (1) do a full build, but deploy only into local dir
    # we will deploy into remote staging repo only once the whole build passed (to save time and bandwith)   
-   ./droolsjbpm-build-bootstrap/script/mvn-all.sh -B -e -U clean deploy -Dfull -Drelease -T2 -DaltDeploymentRepository=local::default::file://$deploy-dir -Dmaven.test.failure.ignore=true -Dgwt.memory.settings="-Xmx4g -Xms1g -Xss1M" -Dgwt.compiler.localWorkers=2
+   ./droolsjbpm-build-bootstrap/script/mvn-all.sh -B -e -U clean deploy -Dfull -Drelease -T2 -DaltDeploymentRepository=local::default::file://$deployDir -Dmaven.test.failure.ignore=true -Dgwt.memory.settings="-Xmx4g -Xms1g -Xss1M" -Dgwt.compiler.localWorkers=2
   
 else
-   deploy-dir=$WORKSPACE/prod-deploy-dir
+   deployDir=$WORKSPACE/prod-deploy-dir
    # (1) do a full build with prod look & feel (-Dproductized), but deploy only into local dir
    # we will deploy into remote staging repo only once the whole build passed (to save time and bandwith)   
-   ./droolsjbpm-build-bootstrap/script/mvn-all.sh -B -e -U clean deploy -Dfull -Dproductized -Drelease -T2 -DaltDeploymentRepository=local::default::file://$deploy-dir -Dmaven.test.failure.ignore=true -Dgwt.memory.settings="-Xmx4g -Xms1g -Xss1M" -Dgwt.compiler.localWorkers=2
+   ./droolsjbpm-build-bootstrap/script/mvn-all.sh -B -e -U clean deploy -Dfull -Dproductized -Drelease -T2 -DaltDeploymentRepository=local::default::file://$deployDir -Dmaven.test.failure.ignore=true -Dgwt.memory.settings="-Xmx4g -Xms1g -Xss1M" -Dgwt.compiler.localWorkers=2
 
 fi


### PR DESCRIPTION
Had to rename the variable deploy-dir to deployDir to prevent the execution of shell script from crashing.