### PR TITLE
PLANNER-870: Bump Roaster version to 2.19.5.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -229,7 +229,7 @@
 
     <!-- Overrides the version in the jboss-integration-platform-bom. A peer PR will be sent to jboss-integration-platform project.
          Please move this new version number there when possible -->
-    <version.org.jboss.forge.roaster>2.19.4.Final</version.org.jboss.forge.roaster>
+    <version.org.jboss.forge.roaster>2.19.5.Final</version.org.jboss.forge.roaster>
     <version.org.jboss.spec.javax.enterprise.concurrent>1.0.0.Final</version.org.jboss.spec.javax.enterprise.concurrent>
     <version.org.jboss.spec.javax.websocket>1.0.0.Final</version.org.jboss.spec.javax.websocket>
   </properties>


### PR DESCRIPTION
Resolves https://issues.jboss.org/browse/ROASTER-116 which causes generic parameters to be ignored in interface definitions

Part of:
https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/537
https://github.com/kiegroup/kie-wb-common/pull/1116