### PR TITLE
Update IDEA code style not to wrap method params and call arguments

### DIFF
--- a/ide-configuration/intellij-configuration/code-style/intellij-code-style_droolsjbpm-java-conventions.xml
+++ b/ide-configuration/intellij-configuration/code-style/intellij-code-style_droolsjbpm-java-conventions.xml
@@ -1,5 +1,5 @@
 <code_scheme name="KIE Java Conventions">
-  <option name="LINE_SEPARATOR" value="&#10;" />
+  <option name="LINE_SEPARATOR" value="&#xA;" />
   <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99999" />
   <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99999" />
   <option name="PACKAGES_TO_USE_IMPORT_ON_DEMAND">
@@ -73,8 +73,6 @@
     <option name="ALIGN_MULTILINE_PARAMETERS_IN_CALLS" value="true" />
     <option name="ALIGN_MULTILINE_FOR" value="false" />
     <option name="ALIGN_MULTILINE_EXTENDS_LIST" value="true" />
-    <option name="CALL_PARAMETERS_WRAP" value="2" />
-    <option name="METHOD_PARAMETERS_WRAP" value="2" />
     <option name="EXTENDS_LIST_WRAP" value="2" />
     <option name="IF_BRACE_FORCE" value="3" />
     <option name="DOWHILE_BRACE_FORCE" value="3" />


### PR DESCRIPTION
Always automatically wrapping method declaration parameters and call arguments is an inconvenient requirement. It [harms readability](https://github.com/jhrcek/guvnor/blob/a81b8781fca06bfdb99fb19a0ccc35314f206b13/guvnor-ala/guvnor-ala-registry-local/src/test/java/org/guvnor/ala/registry/tests/PageSortUtilsTest.java#L81-L101) and is a destructive operation as no IDE is able to revert it even if the rule is lifted. Better to fix the template as soon as possible before more [repositories](https://github.com/kiegroup/optaplanner-wb/pull/179) are [affected](https://github.com/kiegroup/guvnor/pull/478).