### PR TITLE
JBPM-6426: Use of Errai's embedded Wildfly server 10.1.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
     <!-- Required for kie-wb-common to build in IntelliJ Idea 2017, due to -->
     <!-- https://youtrack.jetbrains.com/issue/IDEA-166417 -->
     <!-- Property can be removed when the above issue is fixed -->
-    <version.org.jboss.errai.wildfly>10.0.0.Final</version.org.jboss.errai.wildfly>
+    <version.org.jboss.errai.wildfly>10.1.0.Final</version.org.jboss.errai.wildfly>
 
     <version.org.mortbay.jetty.runner>8.1.7.v20120910</version.org.mortbay.jetty.runner>
     <version.org.picketlink>2.6.0.Final</version.org.picketlink>

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
     <version.org.xmlunit>2.3.0</version.org.xmlunit>
     <version.org.skyscreamer.jsonassert>1.2.3</version.org.skyscreamer.jsonassert>
     <!-- WildFly version used together with  the GWT's Super Dev Mode -->
-    <version.org.wildfly.gwt.sdm>10.0.0.Final</version.org.wildfly.gwt.sdm>
+    <version.org.wildfly.gwt.sdm>10.1.0.Final</version.org.wildfly.gwt.sdm>
     <version.org.wildfly.core>2.1.0.Final</version.org.wildfly.core>
     <version.org.jboss.jboss-dmr>1.3.0.Final</version.org.jboss.jboss-dmr>
     <!-- this version will overwrite jboss-ip-bom version 2.5.1. The version in jboss-ip-bom couldn't be upgraded as it will break ModeShape Web Explorer application which uses GWT 2.5.1 -->


### PR DESCRIPTION
Hey @manstis @psiroky @mbarkley 

As commented on [this ticket](https://issues.jboss.org/browse/JBPM-6426), and trying to actually keep same IDE configurations when running on either `master` either `7.3.x`, this is the version upgrade to `10.1.0.Final` for errai's  embbeded WF stuff. 

I have tested some showcases and the workbench and it seems to work fine, lemme know this sounds good for you or am I missing some parts.

FYI [this is the PR](https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/550) merged on master.

Thanks!
