### PR TITLE
Update Eclipse imports formatter

### DIFF
--- a/ide-configuration/eclipse-configuration/code-style/eclipse-code-style-organize-imports_droolsjbpm-java-conventions.importorder
+++ b/ide-configuration/eclipse-configuration/code-style/eclipse-code-style-organize-imports_droolsjbpm-java-conventions.importorder
@@ -1,5 +1,6 @@
 #Organize Import Order
-#Fri Mar 04 10:06:33 CET 2011
+#Mon Oct 02 11:24:58 CEST 2017
+3=\#
 2=
 1=javax
 0=java


### PR DESCRIPTION
Hi
@ge0ffrey, @manstis, @psiroky, @tarilabs, @mswiderski,

It looks like I forgot to update Eclipse Imports file since it is separate one from main formatter. Here are the fix. (In general the only change is STATIC imports have to be on the bottom). Now it is fully synchronized with IDEA.