### PR TITLE
Revert "override of version of xnio to align to EAP 7.0.8"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -162,10 +162,7 @@
     <!-- narayana dependencies for tomcat and kie server -->
     <version.org.jboss.narayana.tomcat>5.6.4.Final</version.org.jboss.narayana.tomcat>
     <version.org.jboss.transaction.spi>7.6.0.Final</version.org.jboss.transaction.spi>
- 
-    <!-- override of xnio-version to align to EAP 7.0.8 -->
-    <version.org.jboss.xnio>3.4.6.Final</version.org.jboss.xnio>
-    
+
     <!-- In community builds productized is false, in product builds it's true to enable branding changes -->
     <org.kie.productized>false</org.kie.productized>
 


### PR DESCRIPTION
@psiroky @ryanzhang reverted the xnio override as we will do this upgrade in jboss-ip-bom