### PR TITLE
[AF-549-elastic]: modified dependencies to add elasticsearch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
 
     <version.org.mortbay.jetty.runner>8.1.7.v20120910</version.org.mortbay.jetty.runner>
     <version.org.picketlink>2.6.0.Final</version.org.picketlink>
-    <version.com.unboundid>2.3.6</version.com.unboundid>
+    <version.com.unboundid>3.2.0</version.com.unboundid>
     <version.com.wordnik.swagger>1.3.10</version.com.wordnik.swagger>
     <version.io.swagger>1.5.15</version.io.swagger>
     <version.org.jboss.as>7.2.0.Final</version.org.jboss.as>
@@ -156,6 +156,8 @@
     <version.net.sourceforge.cssparser>0.9.21</version.net.sourceforge.cssparser>
     <version.org.w3c.css.sac>1.3</version.org.w3c.css.sac>
 
+    <version.org.apache.lucene>6.6.1</version.org.apache.lucene>
+
     <!-- narayana dependencies for tomcat and kie server -->
     <version.org.jboss.narayana.tomcat>5.6.4.Final</version.org.jboss.narayana.tomcat>
     <version.org.jboss.transaction.spi>7.6.0.Final</version.org.jboss.transaction.spi>
@@ -169,6 +171,11 @@
     <osgi.Bundle-SymbolicName/>
     <!-- Make OSGi happy -->
     <osgi.snapshot.qualifier>${maven.build.timestamp}</osgi.snapshot.qualifier>
+
+    <!-- IMPORTANT: Don't use this dependency. The right dependency version is the one named as "version.io.netty".
+         This is just needed by Elasticsearch Transport Plugin because it has a compatibility mode with netty 3 and
+         it can't be removed -->
+    <version.io.netty.old>3.10.6.Final</version.io.netty.old>
 
     <!-- Plugin version overrides.
          IMPORTANT: always explain the reason for overriding the plugin version! -->
@@ -1875,7 +1882,31 @@
         <artifactId>lucene-queries</artifactId>
         <version>${version.org.apache.lucene}</version>
       </dependency>
-
+      <dependency>
+        <groupId>org.apache.lucene</groupId>
+        <artifactId>lucene-core</artifactId>
+        <version>${version.org.apache.lucene}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.lucene</groupId>
+        <artifactId>lucene-analyzers-common</artifactId>
+        <version>${version.org.apache.lucene}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.lucene</groupId>
+        <artifactId>lucene-queryparser</artifactId>
+        <version>${version.org.apache.lucene}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.lucene</groupId>
+        <artifactId>lucene-misc</artifactId>
+        <version>${version.org.apache.lucene}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty</artifactId>
+        <version>${version.io.netty.old}</version>
+      </dependency>
       <!-- dependency of org.apache.lucene:lucene-sandbox -->
       <dependency>
         <groupId>jakarta-regexp</groupId>
@@ -2127,11 +2158,11 @@
         <artifactId>swagger-annotations</artifactId>
         <version>${version.com.wordnik.swagger}</version>
       </dependency>
-      
+
       <dependency>
         <groupId>io.swagger</groupId>
-	<artifactId>swagger-core</artifactId>
-	<version>${version.io.swagger}</version>
+        <artifactId>swagger-core</artifactId>
+        <version>${version.io.swagger}</version>
       </dependency>
       <dependency>
         <groupId>io.swagger</groupId>


### PR DESCRIPTION
A new Metadata index had been added. Its intention is to have an alternative to Lucene backend so you can use it, for instance in Openshift or on premise without zookeeper/helix to replicate those assets.

The idea is to maintain the same Lucene API but to transform it to Elasticsearch compatible messages. There is no need to change any Lucene Query to make it work. There is a class called **LuceneIndexEngine** that is not **public** anymore because it was very coupled to Lucene FS implementation so now it's behind a new Interface called **IndexProvider**. It tries to generate an abstraction for indexing a querying an index engine using domain objects and not lucene documents anymore.


The default indexing engine is Lucene but you can change it with a System Property:

- org.appformer.ext.metadata.index=elastic

There are some other properties to configure elasticsearch:

- org.appformer.ext.metadata.elastic.port
- org.appformer.ext.metadata.elastic.host
- org.appformer.ext.metadata.elastic.username
- org.appformer.ext.metadata.elastic.password
- org.appformer.ext.metadata.elastic.cluster

Related issues:
https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/581
https://github.com/AppFormer/uberfire/pull/882
https://github.com/kiegroup/kie-wb-common/pull/1254
https://github.com/kiegroup/jbpm-wb/pull/924
https://github.com/kiegroup/drools-wb/pull/666
https://github.com/kiegroup/optaplanner-wb/pull/228
https://github.com/kiegroup/jbpm-form-modeler/pull/150
https://github.com/kiegroup/kie-wb-distributions/pull/642