### PR TITLE
DO NOT MERGE - RHBPMS-5026 - Version difference of jackson artifacts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
          Fabric8 Kubernetes/OpenShift Client 2.6.3 requires Jackson 2.6+, but built against Jackson 2.7.7
          guvnor-ala-openshift-client shades Jackson 2.7.7 with Fabric8 Kubernetes/OpenShift Client 2.6.3
          Once the IP BOM gets upgraded and we solely deploy on Wildfly 10.1+ and EAP 7.1+, guvnor-ala-openshift-client can be removed. -->
-    <version.com.fasterxml.jackson>2.6.2</version.com.fasterxml.jackson>
+    <version.com.fasterxml.jackson>2.8.9</version.com.fasterxml.jackson>
     <version.com.github.detro>1.2.0</version.com.github.detro>
     <version.com.github.tomakehurst.wiremock>1.53</version.com.github.tomakehurst.wiremock>
     <version.com.google.android>4.1.1.4</version.com.google.android>


### PR DESCRIPTION
@mbiarnes @psiroky @krisv @sutaakar 

here are the changes to upgrade version of jackson to 2.8+ as it seems to be required on EAP 7.1

Though this won't work on lower versions like 7.0 or Wildfly 10 and 10.1. I tested this with Wildfly 11 and it does work as expected - tests where only covering what is reported in the jira

PR with code change in droolsjbpm-integration