### PR TITLE
JDK9 build compatibility fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,6 +174,8 @@
          IMPORTANT: always explain the reason for overriding the plugin version! -->
     <!-- Surefire version 2.19.1 coming from parent is buggy and kie-osgi tests in droolsjbpm-integration are failing because of that. -->
     <version.surefire.plugin>2.18.1</version.surefire.plugin>
+    <version.enforcer.plugin>3.0.0-M1</version.enforcer.plugin> <!-- Needed to support JDK 9. Can be removed once IP BOM 8.0.0.CR1 is used. -->
+    <version.javadoc.plugin>3.0.0-M1</version.javadoc.plugin> <!-- Needed to support JDK 9. Can be removed once IP BOM 8.0.0.CR1 is used. -->
     <!-- Jacoco plugin configurations -->
     <jacoco.haltOnFailure>false</jacoco.haltOnFailure>
     <jacoco.line.coveredratio.minimum>0.9</jacoco.line.coveredratio.minimum>

--- a/pom.xml
+++ b/pom.xml
@@ -1588,6 +1588,7 @@
         <!-- There is no public ECJ release (yet) which supports Java 9, so fallback to the native compiler -->
         <!-- TODO remove the line below (and fix the surefire+failsafe config) after resolving https://issues.jboss.org/browse/DROOLS-1169 -->
         <drools.dialect.java.compiler>NATIVE</drools.dialect.java.compiler>
+        <javadoc.additional.params>-Xdoclint:none --add-modules=java.xml.bind --add-modules=java.xml.ws.annotation --add-modules=java.xml.ws</javadoc.additional.params>
       </properties>
       <build>
         <pluginManagement>
@@ -1608,6 +1609,19 @@
                 <systemPropertyVariables>
                   <drools.dialect.java.compiler>${drools.dialect.java.compiler}</drools.dialect.java.compiler>
                 </systemPropertyVariables>
+              </configuration>
+            </plugin>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-javadoc-plugin</artifactId>
+              <configuration>
+                <additionalDependencies>
+                  <additionalDependency>
+                    <groupId>org.jboss.spec.javax.transaction</groupId>
+                    <artifactId>jboss-transaction-api_1.2_spec</artifactId>
+                    <version>${version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.2_spec}</version>
+                  </additionalDependency>
+                </additionalDependencies>
               </configuration>
             </plugin>
           </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -222,7 +222,7 @@
     <jboss.snapshots.repo.url>https://origin-repository.jboss.org/nexus/content/repositories/snapshots/</jboss.snapshots.repo.url>
 
     <!-- Latest release to be used by api-compatibility-check to check backwards compatibility of the Kie API. -->
-    <version.org.kie.latestFinal.release>7.0.0.Final</version.org.kie.latestFinal.release>
+    <version.org.kie.latestFinal.release>7.4.1.Final</version.org.kie.latestFinal.release>
     <revapi.oldKieVersion>${version.org.kie.latestFinal.release}</revapi.oldKieVersion>
     <revapi.newKieVersion>${project.version}</revapi.newKieVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -608,12 +608,12 @@
         <plugin>
           <groupId>org.revapi</groupId>
           <artifactId>revapi-maven-plugin</artifactId>
-          <version>0.8.1</version>
+          <version>0.9.4</version>
           <dependencies>
             <dependency>
               <groupId>org.revapi</groupId>
               <artifactId>revapi-java</artifactId>
-              <version>0.13.1</version>
+              <version>0.14.3</version>
             </dependency>
           </dependencies>
           <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -1586,31 +1586,11 @@
       </activation>
       <properties>
         <!-- There is no public ECJ release (yet) which supports Java 9, so fallback to the native compiler -->
-        <!-- TODO remove the line below (and fix the surefire+failsafe config) after resolving https://issues.jboss.org/browse/DROOLS-1169 -->
-        <drools.dialect.java.compiler>NATIVE</drools.dialect.java.compiler>
         <javadoc.additional.params>-Xdoclint:none --add-modules=java.xml.bind --add-modules=java.xml.ws.annotation --add-modules=java.xml.ws</javadoc.additional.params>
       </properties>
       <build>
         <pluginManagement>
           <plugins>
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-surefire-plugin</artifactId>
-              <configuration>
-                <systemPropertyVariables>
-                  <drools.dialect.java.compiler>${drools.dialect.java.compiler}</drools.dialect.java.compiler>
-                </systemPropertyVariables>
-              </configuration>
-            </plugin>
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-failsafe-plugin</artifactId>
-              <configuration>
-                <systemPropertyVariables>
-                  <drools.dialect.java.compiler>${drools.dialect.java.compiler}</drools.dialect.java.compiler>
-                </systemPropertyVariables>
-              </configuration>
-            </plugin>
             <plugin>
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-javadoc-plugin</artifactId>


### PR DESCRIPTION
These changes should currently be enough for the simple `mvn clean install` build. We will likely need further fixes for tests - but that can be done separately.