### PR TITLE
AF-593+: Move uberfire-maven-utils to kie-soup.

### DIFF
--- a/kie-platform-bom/pom.xml
+++ b/kie-platform-bom/pom.xml
@@ -65,6 +65,13 @@
         <scope>import</scope>
       </dependency>
       <dependency>
+        <groupId>org.kie.soup</groupId>
+        <artifactId>kie-soup-bom</artifactId>
+        <type>pom</type>
+        <version>${version.org.kie}</version>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>org.dashbuilder</groupId>
         <artifactId>dashbuilder-bom</artifactId>
         <type>pom</type>

--- a/pom.xml
+++ b/pom.xml
@@ -1630,14 +1630,14 @@
         <version>${version.org.uberfire}</version>
       </dependency>
       <dependency>
-        <groupId>org.uberfire</groupId>
-        <artifactId>uberfire-maven-support</artifactId>
-        <version>${version.org.uberfire}</version>
+        <groupId>org.kie.soup</groupId>
+        <artifactId>kie-soup-maven-support</artifactId>
+        <version>${version.org.kie}</version>
       </dependency>
       <dependency>
-        <groupId>org.uberfire</groupId>
-        <artifactId>uberfire-maven-integration</artifactId>
-        <version>${version.org.uberfire}</version>
+        <groupId>org.kie.soup</groupId>
+        <artifactId>kie-soup-maven-integration</artifactId>
+        <version>${version.org.kie}</version>
       </dependency>
       <dependency>
         <groupId>org.kie.soup</groupId>


### PR DESCRIPTION
Please see this [PR](https://github.com/kiegroup/kie-soup/pull/8) for general discussion.