### PR TITLE
Change version to check against with revapi to 7.0.0.Final

### DIFF
--- a/RELEASE-README.md
+++ b/RELEASE-README.md
@@ -426,10 +426,6 @@ If everything is perfect (compiles, Jenkins is all blue, sanity checks succeed a
            this is a property productisation needs to get the last released version on the branch where released from.
            When updated this should be pushed to the branch of the blessed repository
 
-        7. latest released *Final* version, property called `version.org.kie.latestFinal.release`
-           This property needs to be updated only with *Final* releases (not for Betas, CRs, etc). This property is being
-           used to check KIE API backwards compatibility (and there may be other uses as well).
-
     * Commit those changes (so you can tag them properly):
 
         * Add changes from untracked files if there are any. WARNING: DO NOT USE `git add .` . You may accidentally add files that are not meant to be added into git.

--- a/pom.xml
+++ b/pom.xml
@@ -224,8 +224,7 @@
     <jboss.snapshots.repo.url>https://origin-repository.jboss.org/nexus/content/repositories/snapshots/</jboss.snapshots.repo.url>
 
     <!-- Latest release to be used by api-compatibility-check to check backwards compatibility of the Kie API. -->
-    <version.org.kie.latestFinal.release>7.4.1.Final</version.org.kie.latestFinal.release>
-    <revapi.oldKieVersion>${version.org.kie.latestFinal.release}</revapi.oldKieVersion>
+    <revapi.oldKieVersion>7.0.0.Final</revapi.oldKieVersion>
     <revapi.newKieVersion>${project.version}</revapi.newKieVersion>
 
     <!-- using undertow for kie server router - same version as it comes with WildFly 10.0.0.Final-->

--- a/script/utils/revapi-clean.sh
+++ b/script/utils/revapi-clean.sh
@@ -4,8 +4,8 @@
 usage ()
 {
   echo "################################## Revapi clean ##################################"
-  echo "Usage : `basename $0` <latestFinalCommunityVersion> <futureFinalCommunityVersion>"
-  echo "        for example: ./revapi-clean.sh 7.0.0.Final 7.1.0.Final"
+  echo "Usage : `basename $0` <finalCommunityVersionToCheckAgainst>"
+  echo "        for example: ./`basename $0` 7.0.0.Final"
   echo "        OR"
   echo "        `basename $0` -h for help"
   echo "##################################################################################"
@@ -16,11 +16,11 @@ getopts :h opt
 
 if [ "$opt" == "h" ]; then
     usage
-elif [ "$#" -ne 2 ]; then
+elif [ "$#" -ne 1 ]; then
     usage
 else
     # First, delete ignores
     find . -iname "revapi-config.json" -exec perl -i -0pe 's/("ignore":.*?)\[.*\]/\1\[\]/s' {} \;
     # Secondly, change versions in the comment
-    find . -iname "revapi-config.json" -exec perl -i -0pe "s/(\"Changes between).*(and the current branch.*when).*(is available)/\1 $1 \2 $2 \3/s" {} \;
+    find . -iname "revapi-config.json" -exec perl -i -0pe "s/(\"Changes between).*(and the current branch.)/\1 $1 \2/s" {} \;
 fi


### PR DESCRIPTION
Hi, @psiroky,

here is the change we spoke about. So I put back the version we check against to 7.0.0.Final and removed version.org.kie.latestFinal.release property too since it is useless now. I have also gone through revapi-config.json files and updated their ignores and their comments so they are not confusing.

PR set:
- https://github.com/kiegroup/droolsjbpm-knowledge/pull/278
- https://github.com/kiegroup/jbpm/pull/1053
- https://github.com/kiegroup/drools/pull/1573
- https://github.com/kiegroup/droolsjbpm-integration/pull/1255
- https://github.com/kiegroup/optaplanner/pull/348

Thanks,

Marian
