### PR TITLE
Setup fixes in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -860,7 +860,7 @@ Extra Eclipse plugins
 
     * [Download and install the Eclipse GWT plugin](http://gwt-plugins.github.io/documentation/gwt-eclipse-plugin/Download.html)
 
-        * Note: it is recommended to keep your Eclipse GWT plugin version in sync with the GWT version that we use.
+        * Note: it is recommended to use the same [GWT SDK version](https://developers.google.com/eclipse/docs/using_sdks#selecting-sdks-for-a-project) like the GWT version it is used in [droolsjbpm-build-bootstrap/pom.xml](pom.xml) `version.com.google.gwt` property value.
 
     * In *Package Explorer*, right click on the project `guvnor-webapp`, menu item *Properties*.
 

--- a/README.md
+++ b/README.md
@@ -858,7 +858,7 @@ Extra Eclipse plugins
 
 * GWT plugin
 
-    * [Download and install the Eclipse GWT plugin](http://code.google.com/intl/en/eclipse/docs/getting_started.html)
+    * [Download and install the Eclipse GWT plugin](http://gwt-plugins.github.io/documentation/gwt-eclipse-plugin/Download.html)
 
         * Note: it is recommended to keep your Eclipse GWT plugin version in sync with the GWT version that we use.
 


### PR DESCRIPTION
Going through GWT plugin setup in Eclipse I found some very probably not up to date things:
* my comment about same versions of GWT SDKs at https://github.com/kiegroup/droolsjbpm-build-bootstrap/commit/783318a087cb5d0218e4e07bf789d7ba3f010047#commitcomment-25476906
* fixed link to GWT plugin page download.