### PR TITLE
update dependencies for FormGenerationIntegrationTest

### DIFF
--- a/kie-bom/pom.xml
+++ b/kie-bom/pom.xml
@@ -1703,6 +1703,12 @@
       </dependency>
       <dependency>
         <groupId>org.kie.workbench.forms</groupId>
+        <artifactId>kie-wb-common-forms-jbpm-integration-backend</artifactId>
+        <version>${version.org.kie}</version>
+        <type>test-jar</type>
+      </dependency>
+      <dependency>
+        <groupId>org.kie.workbench.forms</groupId>
         <artifactId>kie-wb-common-forms-jbpm-integration-client</artifactId>
         <version>${version.org.kie}</version>
       </dependency>


### PR DESCRIPTION
This pr updates the dependencies for the FormGenerationIntegrationTest. This pull-request is to be merged together with https://github.com/kiegroup/kie-wb-common/pull/1288.

@pefernan, @triceo, @jhrcek, @rsynek could you please review?