### PR TITLE
AF-593+: Move uberfire to appformer.

### DIFF
--- a/script/branch-mapping.yaml
+++ b/script/branch-mapping.yaml
@@ -5,8 +5,6 @@
 #  - [<org.unit>/]<repo>: <branch> -- <org.unit> is optional in case it's equal to the repo name
 master:
   - errai/errai: master
-  - kiegroup/kie-soup: master
-  - AppFormer/uberfire: master
 
 7.4.x:
   - errai/errai: 4.0.x

--- a/script/repository-list.txt
+++ b/script/repository-list.txt
@@ -1,3 +1,5 @@
+kie-soup
+appformer
 droolsjbpm-build-bootstrap
 droolsjbpm-knowledge
 drools


### PR DESCRIPTION
@psiroky Could you please review this? The primary goal of this PR set is to replace AppFormer/uberfire with kiegroup/appformer in the build (content being presently almost identical). I figgured it made sense to add kie-soup to the repositories list now too, but I don't have to do that here.