### PR TITLE
Remove useles avalon-framework dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,6 @@
     <!-- New and overwritten dependencies -->
     <!-- ################################################################################ -->
     <version.javaee.api>7.0</version.javaee.api>
-    <version.avalon-framework>4.1.4</version.avalon-framework>
     <version.com.android-dx>1.10</version.com.android-dx>
     <!-- commons cli 1.3.1+ required by Dashbuilder's ElasticSearch module. This override can be removed once IP BOM upgrades as well. -->
     <version.commons-cli>1.3.1</version.commons-cli>
@@ -1696,11 +1695,6 @@
         <groupId>javax</groupId>
         <artifactId>javaee-api</artifactId>
         <version>${version.javaee.api}</version>
-      </dependency>
-      <dependency>
-        <groupId>avalon-framework</groupId>
-        <artifactId>avalon-framework</artifactId>
-        <version>${version.avalon-framework}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
avalon-framework is unused dependency declared (only in) jbpm-designer-backend. It's a project that is no longer maintained since 2004. I'm removing it to remove useless jar from final kie-wb.war

Depends on https://github.com/kiegroup/jbpm-designer/pull/710

