### PR TITLE
[7.5.x] DROOLS-2165: Upgrade revapi-maven-plugin from 0.9.4 to 0.9.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -625,7 +625,7 @@
         <plugin>
           <groupId>org.revapi</groupId>
           <artifactId>revapi-maven-plugin</artifactId>
-          <version>0.9.4</version>
+          <version>0.9.5</version>
           <dependencies>
             <dependency>
               <groupId>org.revapi</groupId>


### PR DESCRIPTION
(cherry picked from commit 6b49066cc74fedd0c3a6efe06660562da1ce6b7b)