### PR TITLE
upgraded appformer version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <version.org.optaplanner>${version.org.kie}</version.org.optaplanner>
     <version.org.jbpm>${version.org.kie}</version.org.jbpm>
     <version.org.drools.droolsjbpm-integration>${version.org.drools}</version.org.drools.droolsjbpm-integration>
-    <version.org.uberfire>2.1.0-SNAPSHOT</version.org.uberfire>
+    <version.org.uberfire>2.2.1-SNAPSHOT</version.org.uberfire>
     <version.org.kie.uberfire.extensions>${version.org.drools}</version.org.kie.uberfire.extensions>
     <version.org.drools.droolsjbpm-tools>${version.org.drools}</version.org.drools.droolsjbpm-tools>
     <version.org.jbpm.jbpm-designer>${version.org.jbpm}</version.org.jbpm.jbpm-designer>


### PR DESCRIPTION
during kie 7.5.0.Final release appformer was upgraded by error to 2.2.0.Final instead of 2.1.0.Final. So 2.2.0.Final is existing. We should upgrade the appformer develop version to 2.2.1-SNAPSHOT 