### PR TITLE
RHDM-240 Adding kie-pmml artifact into drools-bom

### DIFF
--- a/drools-bom/pom.xml
+++ b/drools-bom/pom.xml
@@ -232,6 +232,17 @@
       </dependency>
       <dependency>
         <groupId>org.drools</groupId>
+        <artifactId>kie-pmml</artifactId>
+        <version>${version.org.kie}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.drools</groupId>
+        <artifactId>kie-pmml</artifactId>
+        <version>${version.org.kie}</version>
+        <classifier>sources</classifier>
+      </dependency>
+      <dependency>
+        <groupId>org.drools</groupId>
         <artifactId>drools-workbench-models-commons</artifactId>
         <version>${version.org.kie}</version>
       </dependency>


### PR DESCRIPTION
@mariofusco @lanceleverich Hi, Could you please look that if we need to add kie-pmml into drools-bom?
QE reports an issue on https://issues.jboss.org/browse/RHDM-240 .
