### PR TITLE
RHDM-24: upgrade wildfly swarm to 2017.12.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -219,7 +219,7 @@
     <!-- Version of the KIE Workbench application. Shown for example in About dialog. Will be usually overridden by productisation. -->
     <version.org.kie.workbench.app>${version.org.kie}</version.org.kie.workbench.app>
 
-    <version.org.wildfly.swarm>2017.8.0</version.org.wildfly.swarm>
+    <version.org.wildfly.swarm>2017.12.1</version.org.wildfly.swarm>
     <version.net.byte-buddy>1.4.16</version.net.byte-buddy>
     <version.commons-beanutils>1.9.2</version.commons-beanutils>
     <version.docker-client>3.5.12</version.docker-client>


### PR DESCRIPTION
Fixing version differences in wildfly swarm fraction and standalon DM workbenches.