### PR TITLE
JBPM-6700: Upgrade to Lienzo 2.0.295-RELEASE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,8 +146,8 @@
     <version.javax.validation>1.0.0.GA</version.javax.validation>
 
     <!-- Lienzo core upgrade required by Stunner. Can be removed once IP BOM is upgraded.-->
-    <version.com.ahome-it.lienzo-core>2.0.294-RELEASE</version.com.ahome-it.lienzo-core>
-    <version.com.ahome-it.lienzo-tests>2.0.294-RELEASE</version.com.ahome-it.lienzo-tests>
+    <version.com.ahome-it.lienzo-core>2.0.295-RELEASE</version.com.ahome-it.lienzo-core>
+    <version.com.ahome-it.lienzo-tests>2.0.295-RELEASE</version.com.ahome-it.lienzo-tests>
 
     <!-- JGIT 4.8.0.201706111038-r required by UberFire/AppFormer. Can be removed once IP BOM is upgraded.-->
     <version.org.eclipse.jgit>4.8.0.201706111038-r</version.org.eclipse.jgit>


### PR DESCRIPTION
Hey @manstis @tiagodolphine 

Here is the upgrade to latest lienzo release. See [JBPM-6700](https://issues.jboss.org/browse/JBPM-6700) for more details about it.

Notice created the PR for IP BOM as well  https://github.com/jboss-integration/jboss-integration-platform-bom/pull/415

Thanks!!