### PR TITLE
JBPM-6748: Removed Stunner's BasicSet artifacts from KIE BOM

### DIFF
--- a/kie-bom/pom.xml
+++ b/kie-bom/pom.xml
@@ -2063,47 +2063,6 @@
         <classifier>sources</classifier>
       </dependency>
 
-      <!-- Stunner - Basic Set-->
-
-      <dependency>
-        <groupId>org.kie.workbench.stunner</groupId>
-        <artifactId>kie-wb-common-stunner-basicset-api</artifactId>
-        <version>${version.org.kie}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.kie.workbench.stunner</groupId>
-        <artifactId>kie-wb-common-stunner-basicset-api</artifactId>
-        <version>${version.org.kie}</version>
-        <classifier>sources</classifier>
-      </dependency>
-
-      <dependency>
-        <groupId>org.kie.workbench.stunner</groupId>
-        <artifactId>kie-wb-common-stunner-basicset-backend</artifactId>
-        <version>${version.org.kie}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.kie.workbench.stunner</groupId>
-        <artifactId>kie-wb-common-stunner-basicset-backend</artifactId>
-        <version>${version.org.kie}</version>
-        <classifier>sources</classifier>
-      </dependency>
-
-      <dependency>
-        <groupId>org.kie.workbench.stunner</groupId>
-        <artifactId>kie-wb-common-stunner-basicset-client</artifactId>
-        <version>${version.org.kie}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.kie.workbench.stunner</groupId>
-        <artifactId>kie-wb-common-stunner-basicset-client</artifactId>
-        <version>${version.org.kie}</version>
-        <classifier>sources</classifier>
-      </dependency>
-
       <!-- Stunner - BPMN-->
 
       <dependency>


### PR DESCRIPTION
Hey @manstis @jomarko @hasys 

This commit removes the Stunner's `BasicSet` stuff. It's not being used at all, even nobody cares about it, so as I'd been incrementally moving all shapes from this module into the `stunner-client-shapes` one, this can be removed at this point.

Please merge at same time as:
- https://github.com/kiegroup/kie-wb-common/pull/1362
- https://github.com/kiegroup/kie-wb-distributions/pull/670
- https://github.com/kiegroup/jbpm-wb/pull/971/

See [JBPM-6748](https://issues.jboss.org/browse/JBPM-6748).

Thanks!


