### PR TITLE
Add Guice to pom.xml and remove all of its exclusions.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,7 @@
     <version.com.google.gwt>2.8.2</version.com.google.gwt>
     <version.net.ltgt.gwt.maven>1.0-rc-6</version.net.ltgt.gwt.maven>
     <version.com.google.guava>20.0</version.com.google.guava>
+    <version.com.google.inject.guice>4.0</version.com.google.inject.guice>
     <!-- this version will overwrite jboss-ip-version 3.1.2. The version in jboss-ip-bom couldn't be upgraded as this version needs GWT 2.7.0 -->
     <!-- please look at https://github.com/fredsa/gwt-dnd/wiki/GettingStarted -->
     <version.com.allen-sauer.gwt.dnd>3.3.3</version.com.allen-sauer.gwt.dnd>
@@ -1746,6 +1747,12 @@
       </dependency>
 
       <dependency>
+        <groupId>com.google.inject</groupId>
+        <artifactId>guice</artifactId>
+        <version>${version.com.google.inject.guice}</version>
+      </dependency>
+
+      <dependency>
         <groupId>com.google.gwt.gwtmockito</groupId>
         <artifactId>gwtmockito</artifactId>
         <version>${version.com.google.gwt.gwtmockito}</version>
@@ -1872,12 +1879,6 @@
         <groupId>org.eclipse.sisu</groupId>
         <artifactId>org.eclipse.sisu.inject</artifactId>
         <version>${version.org.eclipse.sisu}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>com.google.inject</groupId>
-            <artifactId>guice</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
 
       <dependency>
@@ -1887,50 +1888,26 @@
         <classifier>runtime</classifier>
       </dependency>
 
-      <!-- Errai (needed for Guice exclusion) -->
+      <!-- Errai -->
       <dependency>
         <groupId>org.jboss.errai</groupId>
         <artifactId>errai-bus</artifactId>
         <version>${version.org.jboss.errai}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>com.google.inject</groupId>
-            <artifactId>guice</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.jboss.errai</groupId>
         <artifactId>errai-ioc</artifactId>
         <version>${version.org.jboss.errai}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>com.google.inject</groupId>
-            <artifactId>guice</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.jboss.errai</groupId>
         <artifactId>errai-tools</artifactId>
         <version>${version.org.jboss.errai}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>com.google.inject</groupId>
-            <artifactId>guice</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.jboss.errai</groupId>
         <artifactId>errai-cdi-server</artifactId>
         <version>${version.org.jboss.errai}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>com.google.inject</groupId>
-            <artifactId>guice</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
 
       <dependency>

--- a/script/repository-list.txt
+++ b/script/repository-list.txt
@@ -1,6 +1,6 @@
 kie-soup
-appformer
 droolsjbpm-build-bootstrap
+appformer
 droolsjbpm-knowledge
 drlx-parser
 drools


### PR DESCRIPTION
This PR should fix the failing tests in https://github.com/kiegroup/appformer/pull/126 caused by `java.lang.NoClassDefFoundError: com/google/inject/Module`.

The https://github.com/kiegroup/appformer/pull/126 PR changes the parent of AppFormer from `jboss-integration-platform-bom` to `kie-parent`.

Another linked PR: https://github.com/jboss-integration/jboss-integration-platform-bom/pull/414.