### PR TITLE
[7.5.x] AF-960: removed shaded docker-client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2322,7 +2322,7 @@
       <dependency>
         <groupId>com.spotify</groupId>
         <artifactId>docker-client</artifactId>
-        <classifier>shaded</classifier>
+<!--         <classifier>shaded</classifier> -->
         <version>${version.docker-client}</version>
         <exclusions>
           <exclusion>


### PR DESCRIPTION
https://issues.jboss.org/browse/AF-960