### PR TITLE
Override ShrinkWrap Resolver version with 3.1.0 until jboss-integrati…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,8 @@
     <version.org.skyscreamer.jsonassert>1.2.3</version.org.skyscreamer.jsonassert>
     <!-- WildFly version used together with  the GWT's Super Dev Mode -->
     <version.org.wildfly.gwt.sdm>10.1.0.Final</version.org.wildfly.gwt.sdm>
+    <!-- Overridden until jboss-integration-platform-parent is upgraded -->
+    <version.org.jboss.shrinkwrap.resolver>3.1.0</version.org.jboss.shrinkwrap.resolver>
     <version.org.jboss.jboss-dmr>1.3.0.Final</version.org.jboss.jboss-dmr>
     <!-- this version will overwrite jboss-ip-bom version 2.5.1. The version in jboss-ip-bom couldn't be upgraded as it will break ModeShape Web Explorer application which uses GWT 2.5.1 -->
     <!-- please look at https://github.com/fredsa/gwt-dnd/wiki/GettingStarted -->


### PR DESCRIPTION
…on-platform-parent is upgraded

Hi, @mareknovotny,

this is a temporary solution until we upgrade jboss-integration-platform-bom version (https://github.com/jboss-integration/jboss-integration-platform-bom/pull/416)

Will execute full downstream build to check if everything is OK.

Thanks.