### PR TITLE
Add --target-repo option to git-all.sh and mvn-all.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,11 @@ Running the build
 
     * Note: the `mvn-all.sh` script is working directory independent.
 
+* You can use `mvn-all.sh` to compile a specific repository and all repositories that your target repository depends on.
+  This is done using the `--target-repo` option which will invoke `repo-dep-tree.pl` script to discover cross-repository
+  project dependencies. Use `--repo-list` to specify custom list of repositories. These options work for `git-all.sh`
+  too.
+
 * Warning: The first `mvn` build of a day will download the latest SNAPSHOT dependencies of other kiegroup projects,
 unless you build all those kiegroup projects from source.
 Those SNAPSHOTS were build and deployed last night by Jenkins jobs.

--- a/script/git-all.sh
+++ b/script/git-all.sh
@@ -29,6 +29,11 @@ GIT_ARG_LINE=()
 for arg in "$@"
 do
     case "$arg" in
+        --target-repo=*)
+            REPOSITORY_LIST=$($scriptDir/checks/repo-dep-tree.pl -w -t ${arg#*=})
+            REPOSITORY_LIST=${REPOSITORY_LIST//,/ }
+        ;;
+
         --repo-list=*)
             REPOSITORY_LIST=$(echo "$arg" | sed 's/[-a-zA-Z0-9]*=//')
             # replace the commas with spaces so that the for loop treats the individual repos as different values

--- a/script/mvn-all.sh
+++ b/script/mvn-all.sh
@@ -23,13 +23,14 @@ initializeWorkingDirAndScriptDir() {
 printUsage() {
     echo
     echo "Usage:"
-    echo "  $0 <Maven arguments> [--repo-list=<list-of-repositories>] [--clean-up-script=<absolute-path>]"
+    echo "  $0 <Maven arguments> [--repo-list=<list-of-repositories>|--target-repo=<repository>] [--clean-up-script=<absolute-path>]"
     echo "For example:"
     echo "  $0 --version"
     echo "  $0 -DskipTests clean install"
     echo "  $0 -Dfull clean install"
     echo "  $0 clean test --repo-list=drools,jbpm"
     echo "  $0 clean test --clean-up-script=\`pwd\`/remove-big-dirs.sh"
+    echo "  $0 clean install --target-repo=drools-wb"
     echo
 }
 
@@ -43,6 +44,11 @@ MVN_ARG_LINE=()
 for arg in "$@"
 do
     case "$arg" in
+        --target-repo=*)
+            REPOSITORY_LIST=$($scriptDir/checks/repo-dep-tree.pl -w -t ${arg#*=})
+            REPOSITORY_LIST=${REPOSITORY_LIST//,/ }
+        ;;
+
         --repo-list=*)
             REPOSITORY_LIST=$(echo $arg | sed 's/[-a-zA-Z0-9]*=//')
             # replace the commas with spaces so that the for loop treats the individual repos as different values


### PR DESCRIPTION
With this option I can run `mvn-all.sh clean install --target-repo=drools-wb` and only build the repositories that `drools-wb` depends on:
* kie-soup
* appformer
* droolsjbpm-build-bootstrap
* drlx-parser
* droolsjbpm-knowledge
* drools
* jbpm
* optaplanner
* droolsjbpm-integration
* kie-wb-playground
* kie-wb-common
* drools-wb

which is 12 out of 20. This can be handy when building a local feature that spans multiple repositories. See the full dependency graph generated by the `repo-dep-tree.pl` script.

![dep-tree dot](https://user-images.githubusercontent.com/673386/35281491-56e767ae-0053-11e8-8343-29981c327d8a.png)
