### PR TITLE
JBPM-6794 - updating eclipse.bpmn2 version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,7 @@
          Fabric8 Kubernetes/OpenShift Client 2.6.3 requires Jackson 2.6+, but built against Jackson 2.7.7
          guvnor-ala-openshift-client shades Jackson 2.7.7 with Fabric8 Kubernetes/OpenShift Client 2.6.3
          Once the IP BOM gets upgraded and we solely deploy on Wildfly 10.1+ and EAP 7.1+, guvnor-ala-openshift-client can be removed. -->
+    <version.org.eclipse.bpmn2>0.8.2-jboss</version.org.eclipse.bpmn2>
     <version.com.fasterxml.jackson>2.6.2</version.com.fasterxml.jackson>
     <version.com.github.detro>1.2.0</version.com.github.detro>
     <version.com.github.tomakehurst.wiremock>1.53</version.com.github.tomakehurst.wiremock>


### PR DESCRIPTION
sets the new org.eclipse.bpmn2 version until we align with platform bom changes. 

related to https://github.com/jboss-integration/jboss-integration-platform-bom/pull/419