### PR TITLE
[RHDM-349]: Added drools playground dependency

### DIFF
--- a/drools-bom/pom.xml
+++ b/drools-bom/pom.xml
@@ -410,6 +410,13 @@
         <scope>test</scope>
       </dependency>
 
+      <!--KIE Drools Workbench Playground -->
+      <dependency>
+        <groupId>org.kie.workbench.playground</groupId>
+        <artifactId>kie-decision-playground</artifactId>
+        <version>${version.org.kie}</version>
+      </dependency>
+
       <dependency>
         <groupId>org.kie</groupId>
         <!-- Does this belong in the kie-bom or in the drools-bom ? -->
@@ -587,8 +594,8 @@
         <version>${version.org.kie}</version>
         <classifier>sources</classifier>
       </dependency>
-      
-      
+
+
       <!-- DRL Extension -->
       <dependency>
         <groupId>org.drools</groupId>
@@ -601,7 +608,6 @@
         <version>${version.org.kie}</version>
         <classifier>sources</classifier>
       </dependency>
-      
 
 
       <!--Categories Editor-->

--- a/kie-bom/pom.xml
+++ b/kie-bom/pom.xml
@@ -541,7 +541,7 @@
       <!-- KIE Workbench Playground Repository -->
       <dependency>
         <groupId>org.kie.workbench.playground</groupId>
-        <artifactId>playground-parent</artifactId>
+        <artifactId>kie-all-playground</artifactId>
         <version>${version.org.kie}</version>
       </dependency>
 

--- a/optaplanner-bom/pom.xml
+++ b/optaplanner-bom/pom.xml
@@ -418,6 +418,12 @@
         <version>${version.org.kie}</version>
         <classifier>sources</classifier>
       </dependency>
+      <!--KIE Drools Workbench Playground -->
+      <dependency>
+        <groupId>org.kie.workbench.playground</groupId>
+        <artifactId>kie-decision-playground</artifactId>
+        <version>${version.org.kie}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
@porcelli could you review?

https://issues.jboss.org/browse/RHDM-349

Related to:
https://github.com/kiegroup/optaplanner-wb/pull/250
https://github.com/kiegroup/drools-wb/pull/799
https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/692
https://github.com/kiegroup/kie-wb-distributions/pull/685
https://github.com/kiegroup/kie-wb-playground/pull/46
https://github.com/kiegroup/jbpm-wb/pull/980
https://github.com/kiegroup/kie-wb-common/pull/1411