### PR TITLE
added lienzo-core and lienzo-tests into repository-list

### DIFF
--- a/script/repository-list.txt
+++ b/script/repository-list.txt
@@ -1,3 +1,5 @@
+lienzo-core
+lienzo-tests
 kie-soup
 appformer
 droolsjbpm-build-bootstrap


### PR DESCRIPTION
@romartin @krisv both repositories have to be in repository list, as the DSL Jenkins groovy script works with the repository-list.txt. The upstream repos are defined depending where is the rep to build listed. If it is not in this list all repositories are build as upstream-repos, and this doesn't make any sense.