### PR TITLE
[7.5.x] DROOLS-2314 : Standalone decision central is not branded

### DIFF
--- a/kie-bom/pom.xml
+++ b/kie-bom/pom.xml
@@ -2308,9 +2308,23 @@
       </dependency>
       <dependency>
         <groupId>org.kie</groupId>
+        <artifactId>kie-drools-wb-webapp</artifactId>
+        <version>${version.org.kie}</version>
+        <type>jar</type>
+        <classifier>swarm</classifier>
+      </dependency>
+      <dependency>
+        <groupId>org.kie</groupId>
         <artifactId>kie-wb-webapp</artifactId>
         <version>${version.org.kie}</version>
         <type>war</type>
+      </dependency>
+      <dependency>
+        <groupId>org.kie</groupId>
+        <artifactId>kie-wb-webapp</artifactId>
+        <version>${version.org.kie}</version>
+        <type>jar</type>
+        <classifier>swarm</classifier>
       </dependency>
       <dependency>
         <groupId>org.kie</groupId>


### PR DESCRIPTION
(cherry picked from commit 67d99eb46911be478c7c4aee3a9aef71b242b483)

https://issues.jboss.org/browse/RHDM-344
https://issues.jboss.org/browse/DROOLS-2314

Bundle:
https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/708
https://github.com/kiegroup/kie-wb-distributions/pull/689