### PR TITLE
[7.7.x] Use the Uberfire 2.4.1-SNAPSHOT version for the 7.7.x branch.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <version.org.optaplanner>${version.org.kie}</version.org.optaplanner>
     <version.org.jbpm>${version.org.kie}</version.org.jbpm>
     <version.org.drools.droolsjbpm-integration>${version.org.drools}</version.org.drools.droolsjbpm-integration>
-    <version.org.uberfire>2.4.0-SNAPSHOT</version.org.uberfire>
+    <version.org.uberfire>2.4.1-SNAPSHOT</version.org.uberfire>
     <version.org.kie.uberfire.extensions>${version.org.drools}</version.org.kie.uberfire.extensions>
     <version.org.drools.droolsjbpm-tools>${version.org.drools}</version.org.drools.droolsjbpm-tools>
     <version.org.jbpm.jbpm-designer>${version.org.jbpm}</version.org.jbpm.jbpm-designer>


### PR DESCRIPTION
Hey @ederign @mbiarnes @mareknovotny @manstis 

Well not sure if I'm wrong or how things are really building fine on the `7.7.x` branch... but it seems it's using the wrong version for uberfire artifacts! 

So the build for `7.7.x` now it's broken as from merging https://github.com/kiegroup/kie-wb-common/pull/1559, but it's due to `kie-wb-common` is still using uberfire `2.4.0-SNAPSHOT` instead of `2.4.1-SNAPSHOT`, right? See https://github.com/kiegroup/droolsjbpm-build-bootstrap/blob/7.7.x/pom.xml#L53

Anyway please if you agree this should be merged asap, lemme know. Thanks!