### PR TITLE
[7.7.X] AF-1079: Empty 'Validation errors' popup in Decision/Business Central

### DIFF
--- a/kie-bom/pom.xml
+++ b/kie-bom/pom.xml
@@ -607,6 +607,19 @@
         <classifier>sources</classifier>
       </dependency>
 
+      <!--Testing-->
+      <dependency>
+        <groupId>org.kie.workbench</groupId>
+        <artifactId>kie-wb-testing-utils</artifactId>
+        <version>${version.org.kie}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.kie.workbench</groupId>
+        <artifactId>kie-wb-testing-utils</artifactId>
+        <version>${version.org.kie}</version>
+        <classifier>sources</classifier>
+      </dependency>
+
       <!--Core API-->
       <dependency>
         <groupId>org.kie.workbench.services</groupId>


### PR DESCRIPTION
(cherry picked from commit 1024e66cc0b65f538bc9c943aaa770fe34f8d33e)

https://issues.jboss.org/browse/AF-1079

https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/731
https://github.com/kiegroup/appformer/pull/272
https://github.com/kiegroup/kie-wb-common/pull/1565
https://github.com/kiegroup/drools-wb/pull/841