### PR TITLE
Upgrade maven version to 3.5.0 for productized maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,7 @@
     <version.link.bek.tools.issue-keeper-junit>4.11.1</version.link.bek.tools.issue-keeper-junit>
     <version.net.sf.docbook.docbook-xsl>1.76.1</version.net.sf.docbook.docbook-xsl>
     <version.org.antlr4>4.5.3</version.org.antlr4>
+    <version.org.apache.maven>3.5.0</version.org.apache.maven>
     <version.org.apache.camel>2.18.2</version.org.apache.camel>
     <version.org.apache.cxf>3.1.10</version.org.apache.cxf>
     <version.org.codehaus.cargo>1.6.6</version.org.codehaus.cargo>


### PR DESCRIPTION
We need to productized the multiple maven components.
So request to upgrade 3.5.0 to match the productized maven components.