### PR TITLE
PLANNER-1026 Add dependencies needed to build optaplanner-wb-webapp

### DIFF
--- a/kie-bom/pom.xml
+++ b/kie-bom/pom.xml
@@ -639,6 +639,12 @@
       <dependency>
         <groupId>org.kie.workbench.services</groupId>
         <artifactId>kie-wb-common-data-modeller-core</artifactId>
+        <version>${version.org.kie}</version>
+        <classifier>sources</classifier>
+      </dependency>
+      <dependency>
+        <groupId>org.kie.workbench.services</groupId>
+        <artifactId>kie-wb-common-data-modeller-core</artifactId>
         <classifier>tests</classifier>
         <version>${version.org.kie}</version>
       </dependency>

--- a/optaplanner-bom/pom.xml
+++ b/optaplanner-bom/pom.xml
@@ -418,6 +418,12 @@
         <version>${version.org.kie}</version>
         <classifier>sources</classifier>
       </dependency>
+      <dependency>
+        <groupId>org.optaplanner</groupId>
+        <artifactId>optaplanner-wb-ui</artifactId>
+        <version>${version.org.kie}</version>
+        <type>war</type>
+      </dependency>
       <!--KIE Drools Workbench Playground -->
       <dependency>
         <groupId>org.kie.workbench.playground</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1331,6 +1331,11 @@
           <artifactId>exec-maven-plugin</artifactId>
           <version>1.5.0</version>
         </plugin>
+        <plugin>
+          <groupId>org.wildfly.plugins</groupId>
+          <artifactId>wildfly-maven-plugin</artifactId>
+          <version>1.2.0.Final</version>
+        </plugin>
       </plugins>
     </pluginManagement>
 


### PR DESCRIPTION
The update is needed to build OptaPlanner showcase webapp after
migration to tbroyer GWT Maven plugin.