### PR TITLE
RHPAM-1017 Add freemarker into dependencyMgmt

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2678,6 +2678,12 @@
         <version>${version.javax.xml.soap}</version>
       </dependency>
 
+      <dependency>
+        <groupId>org.freemarker</groupId>
+        <artifactId>freemarker</artifactId>
+        <version>${version.org.freemarker}</version>
+      </dependency>
+
     </dependencies>
 
   </dependencyManagement>


### PR DESCRIPTION
Freemarker needs to be added into dependencyMgmt so that product build can override the dependency version to productize version.