### PR TITLE
Exclude transitive Java EE APIs that are obsoleted by JBoss Specs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2716,6 +2716,22 @@
         <version>${version.org.jboss.spec.javax.ws.rs.jboss-jaxrs-api_2.1_spec}</version>
       </dependency>
 
+      <dependency>
+        <groupId>javax.enterprise</groupId>
+        <artifactId>cdi-api</artifactId>
+        <version>${version.javax.enterprise}</version>
+        <!-- Avoid collisions with equivalent JBoss Spec APIs -->
+        <exclusions>
+          <exclusion>
+            <groupId>javax.el</groupId>
+            <artifactId>javax.el-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>javax.interceptor</groupId>
+            <artifactId>javax.interceptor-api</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
     </dependencies>
 
   </dependencyManagement>


### PR DESCRIPTION
This will allow to depend on `javax.enterprise:cdi-api` without having to
exclude `javax.el:javax.el-api` and
`javax.interceptor:javax.interceptor-api` to satisfy the
"banDuplicateClasses" Enforcer rule in situations where the project
also depends on `org.jboss.spec.javax.el:jboss-el-api_3.0_spec`
and `org.jboss.spec.javax.interceptor:jboss-interceptors-api_1.2_spec`.