### PR TITLE
DROOLS-2253: Upgrade protobuf-java from 2.6.0 to 2.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -251,6 +251,7 @@
 
     <version.org.quartz-scheduler>2.2.3</version.org.quartz-scheduler>
 
+    <version.com.google.protobuf>2.6.1</version.com.google.protobuf>
   </properties>
 
   <repositories>


### PR DESCRIPTION
Force update version.com.google.protobuf to be able merge https://github.com/kiegroup/drools/pull/1818 and don't wait for next jboss-integration-platform-bom release