### PR TITLE
DROOLS-2253: Upgrade protobuf-java from 2.6.0 to 2.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -253,6 +253,7 @@
 
     <version.org.jboss.spec.javax.ws.rs.jboss-jaxrs-api_2.1_spec>1.0.0.Final</version.org.jboss.spec.javax.ws.rs.jboss-jaxrs-api_2.1_spec>
 
+    <version.com.google.protobuf>2.6.1</version.com.google.protobuf>
   </properties>
 
   <repositories>


### PR DESCRIPTION
Force update version.com.google.protobuf to be able merge kiegroup/drools#1818 and don't wait for next jboss-integration-platform-bom release.

@mareknovotny , @mariofusco could you please to look at this and merge?