### PR TITLE
AF-1243: Add new drools-wb-ui artifact

### DIFF
--- a/drools-bom/pom.xml
+++ b/drools-bom/pom.xml
@@ -1088,6 +1088,12 @@
       <!--drools-wb distribution-->
       <dependency>
         <groupId>org.drools</groupId>
+        <artifactId>drools-wb-ui</artifactId>
+        <type>war</type>
+        <version>${version.org.kie}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.drools</groupId>
         <artifactId>drools-wb-webapp</artifactId>
         <type>war</type>
         <version>${version.org.kie}</version>


### PR DESCRIPTION
Related PRs:
kiegroup/droolsjbpm-build-bootstrap#766
kiegroup/drools-wb#873

The new artifact is a result of splitting drools-wb-webapp into two
modules, which is a standard layout with the new tbroyer GWT plugin.