### PR TITLE
PLANNER-1063 Remove kie-decision-playground from optaplanner-bom

### DIFF
--- a/optaplanner-bom/pom.xml
+++ b/optaplanner-bom/pom.xml
@@ -424,12 +424,6 @@
         <version>${version.org.kie}</version>
         <type>war</type>
       </dependency>
-      <!--KIE Drools Workbench Playground -->
-      <dependency>
-        <groupId>org.kie.workbench.playground</groupId>
-        <artifactId>kie-decision-playground</artifactId>
-        <version>${version.org.kie}</version>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
Reasons for removing:
1. optaplanner-bom should only contain org.optaplanner.* artifacts.
2. There should be minimal overlaps between BOMs and
   kie-decision-playground is already in drools-bom.

Nothing should break since from all optaplanner-related repos,
kie-decision-playground is only used in optaplanner-wb and that imports
drools-bom.