### PR TITLE
DROOLS-2846 : Move Verifier core from drools-wb to drools

### DIFF
--- a/drools-bom/pom.xml
+++ b/drools-bom/pom.xml
@@ -201,15 +201,39 @@
       </dependency>
       <dependency>
         <groupId>org.drools</groupId>
-        <artifactId>drools-verifier</artifactId>
+        <artifactId>drools-verifier-drl</artifactId>
         <version>${version.org.kie}</version>
       </dependency>
       <dependency>
         <groupId>org.drools</groupId>
-        <artifactId>drools-verifier</artifactId>
+        <artifactId>drools-verifier-drl</artifactId>
         <version>${version.org.kie}</version>
         <classifier>sources</classifier>
       </dependency>
+      <dependency>
+        <groupId>org.drools</groupId>
+        <artifactId>drools-verifier-api</artifactId>
+        <version>${version.org.kie}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.drools</groupId>
+        <artifactId>drools-verifier-api</artifactId>
+        <version>${version.org.kie}</version>
+        <classifier>sources</classifier>
+      </dependency>
+      <dependency>
+        <groupId>org.drools</groupId>
+        <artifactId>drools-verifier-core</artifactId>
+        <version>${version.org.kie}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.drools</groupId>
+        <artifactId>drools-verifier-core</artifactId>
+        <version>${version.org.kie}</version>
+        <classifier>sources</classifier>
+      </dependency>
+
+
       <dependency>
         <groupId>org.drools</groupId>
         <artifactId>drools-persistence-api</artifactId>
@@ -545,7 +569,6 @@
         <version>${version.org.kie}</version>
       </dependency>
 
-      <!--Verification-->
       <dependency>
         <groupId>org.drools</groupId>
         <artifactId>drools-wb-verifier-api</artifactId>
@@ -570,23 +593,23 @@
       </dependency>
       <dependency>
         <groupId>org.drools</groupId>
-        <artifactId>drools-wb-verifier-client</artifactId>
+        <artifactId>drools-wb-verifier-guided-decision-table-adapter</artifactId>
         <version>${version.org.kie}</version>
       </dependency>
       <dependency>
         <groupId>org.drools</groupId>
-        <artifactId>drools-wb-verifier-client</artifactId>
+        <artifactId>drools-wb-verifier-guided-decision-table-adapter</artifactId>
         <version>${version.org.kie}</version>
         <classifier>sources</classifier>
       </dependency>
       <dependency>
         <groupId>org.drools</groupId>
-        <artifactId>drools-wb-verifier-backend</artifactId>
+        <artifactId>drools-wb-verifier-webworker</artifactId>
         <version>${version.org.kie}</version>
       </dependency>
       <dependency>
         <groupId>org.drools</groupId>
-        <artifactId>drools-wb-verifier-backend</artifactId>
+        <artifactId>drools-wb-verifier-webworker</artifactId>
         <version>${version.org.kie}</version>
         <classifier>sources</classifier>
       </dependency>

--- a/kie-bom/pom.xml
+++ b/kie-bom/pom.xml
@@ -1552,6 +1552,30 @@
         <classifier>sources</classifier>
       </dependency>
 
+      <!--Verification-->
+      <dependency>
+        <groupId>org.kie.workbench.services</groupId>
+        <artifactId>kie-wb-common-verifier-api</artifactId>
+        <version>${version.org.kie}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.kie.workbench.services</groupId>
+        <artifactId>kie-wb-common-verifier-api</artifactId>
+        <version>${version.org.kie}</version>
+        <classifier>sources</classifier>
+      </dependency>
+      <dependency>
+        <groupId>org.kie.workbench.services</groupId>
+        <artifactId>kie-wb-common-verifier-reporting</artifactId>
+        <version>${version.org.kie}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.kie.workbench.services</groupId>
+        <artifactId>kie-wb-common-verifier-reporting</artifactId>
+        <version>${version.org.kie}</version>
+        <classifier>sources</classifier>
+      </dependency>
+
       <!-- Kie-wb CLI migration tools -->
       <dependency>
         <groupId>org.kie.workbench</groupId>


### PR DESCRIPTION
https://issues.jboss.org/browse/DROOLS-2846
https://issues.jboss.org/browse/DROOLS-2847

Pretty much just moving code for the 99% of the changes and then 1% of refactorings to make the move easier.

Bundle:
https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/800
https://github.com/kiegroup/drools/pull/2021
https://github.com/kiegroup/kie-wb-common/pull/2054
https://github.com/kiegroup/drools-wb/pull/916
https://github.com/kiegroup/optaplanner-wb/pull/301
https://github.com/kiegroup/kie-wb-distributions/pull/795