### PR TITLE
DROOLS-2848 : Make the Verifier Web Worker connector reusable for different V&V types

### DIFF
--- a/kie-bom/pom.xml
+++ b/kie-bom/pom.xml
@@ -1566,12 +1566,23 @@
       </dependency>
       <dependency>
         <groupId>org.kie.workbench.services</groupId>
-        <artifactId>kie-wb-common-verifier-reporting</artifactId>
+        <artifactId>kie-wb-common-verifier-reporting-client</artifactId>
         <version>${version.org.kie}</version>
       </dependency>
       <dependency>
         <groupId>org.kie.workbench.services</groupId>
-        <artifactId>kie-wb-common-verifier-reporting</artifactId>
+        <artifactId>kie-wb-common-verifier-reporting-client</artifactId>
+        <version>${version.org.kie}</version>
+        <classifier>sources</classifier>
+      </dependency>
+      <dependency>
+        <groupId>org.kie.workbench.services</groupId>
+        <artifactId>kie-wb-common-verifier-service</artifactId>
+        <version>${version.org.kie}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.kie.workbench.services</groupId>
+        <artifactId>kie-wb-common-verifier-service</artifactId>
         <version>${version.org.kie}</version>
         <classifier>sources</classifier>
       </dependency>


### PR DESCRIPTION
Follow up for: https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/800

https://issues.jboss.org/browse/DROOLS-2848
https://issues.jboss.org/browse/DROOLS-2849

Bundle:
https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/809
https://github.com/kiegroup/kie-wb-common/pull/2073
https://github.com/kiegroup/drools-wb/pull/919
https://github.com/kiegroup/optaplanner-wb/pull/302
https://github.com/kiegroup/kie-wb-distributions/pull/802