### PR TITLE
upgraded to jboss-ip-bom 8.1.0.CR2

### DIFF
--- a/kie-user-bom-parent/pom.xml
+++ b/kie-user-bom-parent/pom.xml
@@ -7,7 +7,7 @@
     <groupId>org.jboss.integration-platform</groupId>
     <artifactId>jboss-integration-platform-parent</artifactId>
     <!-- Keep in sync with the parent version in ../pom.xml (kie-parent)  -->
-    <version>8.0.0.Final</version>
+    <version>8.1.0.CR2</version>
     <!-- Empty relativePath needed to fix Maven warning 'parent.relativePath points at wrong POM' -->
     <relativePath/>
   </parent>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <groupId>org.jboss.integration-platform</groupId>
     <artifactId>jboss-integration-platform-bom</artifactId>
     <!-- Keep in sync with ip-parent version in kie-user-bom-parent/pom.xml -->
-    <version>8.0.0.Final</version>
+    <version>8.1.0.CR2</version>
   </parent>
 
   <groupId>org.kie</groupId>
@@ -104,10 +104,7 @@
     <!-- https://youtrack.jetbrains.com/issue/IDEA-166417 -->
     <!-- Property can be removed when the above issue is fixed -->
     <version.org.jboss.errai.wildfly>11.0.0.Final</version.org.jboss.errai.wildfly>
-    <version.org.jboss.remoting>5.0.3.Final</version.org.jboss.remoting>
     <version.org.jboss.remotingjmx>3.0.0.Final</version.org.jboss.remotingjmx>
-    <!--resteasy override: RHPAM-340 -->
-    <version.org.jboss.resteasy>3.0.24.Final</version.org.jboss.resteasy>
     <!-- Required by jboss-remoting version above -->
     <version.org.wildfly.security>1.1.0.Final</version.org.wildfly.security>
 
@@ -120,7 +117,6 @@
     <version.org.jboss.byteman>3.0.1</version.org.jboss.byteman>
     <version.org.roboguice>3.0.1</version.org.roboguice>
     <version.org.robolectric>3.1.2</version.org.robolectric>
-    <version.org.jboss.arquillian.selenium>2.53.0</version.org.jboss.arquillian.selenium>
     <version.org.simpleframework>6.0.1</version.org.simpleframework>
     <version.org.xmlunit>2.3.0</version.org.xmlunit>
     <version.org.skyscreamer.jsonassert>1.2.3</version.org.skyscreamer.jsonassert>
@@ -148,10 +144,6 @@
     <!-- Downgrade required for Errai Dynamic Bean validation  -->
     <version.org.hibernate.hibernate-validator>4.1.0.Final</version.org.hibernate.hibernate-validator>
     <version.javax.validation>1.0.0.GA</version.javax.validation>
-
-    <!-- JGIT 4.8.0.201706111038-r required by UberFire/AppFormer. Can be removed once IP BOM is upgraded.-->
-    <version.org.eclipse.jgit>4.8.0.201706111038-r</version.org.eclipse.jgit>
-    <version.org.apache.sshd>1.6.0</version.org.apache.sshd>
 
     <!-- CSS parsing library from Apache used by Stunner. -->
     <version.net.sourceforge.cssparser>0.9.21</version.net.sourceforge.cssparser>
@@ -241,7 +233,6 @@
     <version.okhttp>3.8.1</version.okhttp>
     <version.zjsonpatch>0.3.0</version.zjsonpatch>
     <version.arquillian-cube>1.0.0.Alpha15</version.arquillian-cube>
-    <version.org.wildfly.arquillian.container>2.0.0.Final</version.org.wildfly.arquillian.container>
     <jboss.releases.repo.url>https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/</jboss.releases.repo.url>
     <jboss.snapshots.repo.url>https://repository.jboss.org/nexus/content/repositories/snapshots/</jboss.snapshots.repo.url>
 
@@ -252,18 +243,11 @@
     <!-- using undertow for kie server router - same version as it comes with WildFly 10.0.0.Final-->
     <version.io.undertow.core>1.3.15.Final</version.io.undertow.core>
 
-    <!-- Overrides the version in the jboss-integration-platform-bom. A peer PR will be sent to jboss-integration-platform project.
-         Please move this new version number there when possible -->
-    <version.org.jboss.forge.roaster>2.19.5.Final</version.org.jboss.forge.roaster>
     <version.org.jboss.spec.javax.enterprise.concurrent>1.0.0.Final</version.org.jboss.spec.javax.enterprise.concurrent>
     <version.org.jboss.spec.javax.websocket>1.1.1.Final</version.org.jboss.spec.javax.websocket>
 
-    <version.org.mvel>2.4.0.Final</version.org.mvel>
-
     <version.javax.xml.soap>1.3.5</version.javax.xml.soap>
     <version.javax.jws>1.0-MR1</version.javax.jws>
-
-    <version.org.quartz-scheduler>2.2.3</version.org.quartz-scheduler>
 
     <version.org.jboss.spec.javax.ws.rs.jboss-jaxrs-api_2.1_spec>1.0.0.Final</version.org.jboss.spec.javax.ws.rs.jboss-jaxrs-api_2.1_spec>
     <version.org.apache.maven.plugins.dependency>3.0.2</version.org.apache.maven.plugins.dependency>
@@ -1717,11 +1701,6 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-          <groupId>org.quartz-scheduler</groupId>
-          <artifactId>quartz</artifactId>
-          <version>${version.org.quartz-scheduler}</version>
-      </dependency>
-      <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-commons</artifactId>
         <version>${version.org.uberfire}</version>
@@ -2089,12 +2068,6 @@
       </dependency>
 
       <dependency>
-        <groupId>org.sonatype.sisu.inject</groupId>
-        <artifactId>guice-servlet</artifactId>
-        <version>${version.org.sonatype.sisu.sisu-guice}</version>
-      </dependency>
-
-      <dependency>
         <groupId>org.springframework.osgi</groupId>
         <artifactId>spring-osgi-core</artifactId>
         <version>${version.org.springframework.osgi}</version>
@@ -2373,95 +2346,6 @@
         <version>${version.org.wildfly.core}</version>
       </dependency>
 
-      <!-- Required by wildfly-core -->
-      <dependency>
-        <groupId>org.jboss.remoting</groupId>
-        <artifactId>jboss-remoting</artifactId>
-        <version>${version.org.jboss.remoting}</version>
-      </dependency>
-
-      <!--resteasy override: RHPAM-340 -->
-      <dependency>
-        <groupId>org.jboss.resteasy</groupId>
-        <artifactId>resteasy-atom-provider</artifactId>
-        <version>${version.org.jboss.resteasy}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jboss.resteasy</groupId>
-        <artifactId>resteasy-cdi</artifactId>
-        <version>${version.org.jboss.resteasy}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jboss.resteasy</groupId>
-        <artifactId>resteasy-client</artifactId>
-        <version>${version.org.jboss.resteasy}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jboss.resteasy</groupId>
-        <artifactId>resteasy-jaxrs</artifactId>
-        <version>${version.org.jboss.resteasy}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jboss.resteasy</groupId>
-        <artifactId>resteasy-jaxb-provider</artifactId>
-        <version>${version.org.jboss.resteasy}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jboss.resteasy</groupId>
-        <artifactId>resteasy-jackson-provider</artifactId>
-        <version>${version.org.jboss.resteasy}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jboss.resteasy</groupId>
-        <artifactId>resteasy-jettison-provider</artifactId>
-        <version>${version.org.jboss.resteasy}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jboss.resteasy</groupId>
-        <artifactId>resteasy-jdk-http</artifactId>
-        <version>${version.org.jboss.resteasy}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jboss.resteasy</groupId>
-        <artifactId>resteasy-multipart-provider</artifactId>
-        <version>${version.org.jboss.resteasy}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jboss.resteasy</groupId>
-        <artifactId>resteasy-netty</artifactId>
-        <version>${version.org.jboss.resteasy}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jboss.resteasy</groupId>
-        <artifactId>async-http-servlet-3.0</artifactId>
-        <version>${version.org.jboss.resteasy}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jboss.resteasy</groupId>
-        <artifactId>resteasy-guice</artifactId>
-        <version>${version.org.jboss.resteasy}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jboss.resteasy</groupId>
-        <artifactId>resteasy-fastinfoset-provider</artifactId>
-        <version>${version.org.jboss.resteasy}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jboss.resteasy</groupId>
-        <artifactId>resteasy-spring</artifactId>
-        <version>${version.org.jboss.resteasy}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jboss.resteasy</groupId>
-        <artifactId>resteasy-yaml-provider</artifactId>
-        <version>${version.org.jboss.resteasy}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jboss.resteasy</groupId>
-        <artifactId>tjws</artifactId>
-        <version>${version.org.jboss.resteasy}</version>
-      </dependency>
-
       <!-- Need newer remoting-jmx to be compatible with newer jboss-remoting -->
       <dependency>
         <groupId>org.jboss.remotingjmx</groupId>
@@ -2618,12 +2502,7 @@
         <artifactId>logging-interceptor</artifactId>
         <version>${version.okhttp}</version>
       </dependency>
-      <!-- httpmime should be moved to jboss-ip-bom/ip-bom/pom.xml > 7.0.0.Final -->
-      <dependency>
-        <groupId>org.apache.httpcomponents</groupId>
-        <artifactId>httpmime</artifactId>
-        <version>${version.org.apache.httpcomponents.httpclient}</version>
-      </dependency>
+
       <dependency>
         <groupId>org.arquillian.cube</groupId>
         <artifactId>arquillian-cube-docker</artifactId>
@@ -2635,21 +2514,11 @@
         <version>${version.arquillian-cube}</version>
       </dependency>
       <dependency>
-        <groupId>org.wildfly.arquillian</groupId>
-        <artifactId>wildfly-arquillian-container-managed</artifactId>
-        <version>${version.org.wildfly.arquillian.container}</version>
-      </dependency>
-      <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>bom</artifactId>
         <version>${version.org.wildfly.swarm}</version>
         <type>pom</type>
         <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.jboss.resteasy</groupId>
-        <artifactId>resteasy-jackson2-provider</artifactId>
-        <version>${version.org.jboss.resteasy}</version>
       </dependency>
 
       <!-- CSS parsing library from Apache used by Stunner. -->
@@ -2754,12 +2623,6 @@
         <groupId>io.undertow</groupId>
         <artifactId>undertow-websockets-jsr</artifactId>
         <version>${version.io.undertow.core}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.mvel</groupId>
-        <artifactId>mvel2</artifactId>
-        <version>${version.org.mvel}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
moved org.apache.sshd and org.eclipse.jgit to jboss-ip-bom

org.sonatype.sisu.sisu-guice: removed dependency since it is already in jboss-ip-bom

org.quartz-scheduler: moved to jboss-ip-bom

org.wildfly.arquillian: moved to jboss ip-bom

org.apache.httpcomponents.httpclient: moved httpmime to jbos-ip-bom

org.jboss.arquillian.selenium: moved to jboss-ip-bom

org.mvel: moved to jboss ip-bom

org.jboss.remoting: moved to jboss-ip-bom

org.jboss.resteasy: moved to jboss-ip-bom

org.jboss.forge.roaster: moved to jboss-ip-bom

upgraded to jboss-ip-bom 8.1.0.CR2