### PR TITLE
[DROOLS-2976] Add build-helper-maven-plugin as managed version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1338,6 +1338,11 @@
           <artifactId>wildfly-maven-plugin</artifactId>
           <version>1.2.0.Final</version>
         </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>build-helper-maven-plugin</artifactId>
+          <version>3.0.0</version>
+        </plugin>
       </plugins>
     </pluginManagement>
 


### PR DESCRIPTION
@manstis @jomarko 
Scope of this PR is to add builder-helper-maven-plugin as managed plugin, to be used inside drools-wb-webapp
