### PR TITLE
BXMSPROD-38: moved org.eclispse.jdt to jboss-ip-bom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2677,11 +2677,6 @@
         <version>${version.org.mvel}</version>
       </dependency>
 
-      <dependency>
-        <groupId>org.eclipse.jdt.core.compiler</groupId>
-        <artifactId>ecj</artifactId>
-        <version>${version.ecj}</version>
-      </dependency>
     </dependencies>
 
   </dependencyManagement>


### PR DESCRIPTION
DON'T MERGE before https://github.com/jboss-integration/jboss-integration-platform-bom/pull/425 was merged and the IP BOM 8.2.0.Final was released and KIE reps updated