### PR TITLE
BAQE-96: Update version of selenium test dependencies (#840)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,8 +94,11 @@
     <version.org.codehaus.cargo>1.6.9</version.org.codehaus.cargo>
     <!-- Custom Freemarker build with workaround for random concurrent access issue (annotation processors). See AF-600 for more info.-->
     <version.org.freemarker>2.3.26.jbossorg-1</version.org.freemarker>
-    <version.org.jboss.arquillian.extension.drone>2.0.0.Final</version.org.jboss.arquillian.extension.drone>
-    <version.org.jboss.arquillian.graphene>2.1.0.CR1</version.org.jboss.arquillian.graphene>
+    <!-- Dependencies for selenium tests -->
+    <version.org.jboss.arquillian.selenium>3.13.0</version.org.jboss.arquillian.selenium>
+    <version.org.jboss.arquillian.extension.drone>2.5.1</version.org.jboss.arquillian.extension.drone>
+    <version.org.jboss.arquillian.graphene>2.3.2</version.org.jboss.arquillian.graphene>
+    <version.com.google.guava.for-selenium>23.0</version.com.google.guava.for-selenium>
 
     <version.com.google.elemental2>1.0.0-beta-1</version.com.google.elemental2>
     <version.org.jboss.errai>4.3.3-SNAPSHOT</version.org.jboss.errai>


### PR DESCRIPTION
Cherry-pick latest selenium version update and timeout stabilizations to 7.11.x

Part of ensemble:
https://github.com/kiegroup/kie-jenkins-scripts/pull/341
https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/846
https://github.com/kiegroup/kie-wb-distributions/pull/825