### PR TITLE
upgrade version io.undertow due to security vulnerability reported by…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -241,7 +241,7 @@
     <revapi.newKieVersion>${project.version}</revapi.newKieVersion>
 
     <!-- using undertow for kie server router - same version as it comes with WildFly 10.0.0.Final-->
-    <version.io.undertow.core>1.3.15.Final</version.io.undertow.core>
+    <version.io.undertow.core>1.3.31.Final</version.io.undertow.core>
 
     <version.org.jboss.spec.javax.enterprise.concurrent>1.0.0.Final</version.org.jboss.spec.javax.enterprise.concurrent>
     <version.org.jboss.spec.javax.websocket>1.1.1.Final</version.org.jboss.spec.javax.websocket>


### PR DESCRIPTION
… github
 
Upgrade io.undertow:undertow-core to version 1.3.31 or later. For example:

<dependency>
  <groupId>io.undertow</groupId>
  <artifactId>undertow-core</artifactId>
  <version>[1.3.31,)</version>
</dependency>

