### PR TITLE
override version of org.apache.cxf

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,8 @@
     <version.link.bek.tools.issue-keeper-junit>4.11.1</version.link.bek.tools.issue-keeper-junit>
     <version.net.sf.docbook.docbook-xsl>1.76.1</version.net.sf.docbook.docbook-xsl>
     <version.org.antlr4>4.5.3</version.org.antlr4>
+    <!-- overrides version of cxf coming from jboss-ip-bom 8.3.2.Final since tests in kie-spring-boot (droolsjbpm-integration) fail -->
+    <version.org.apache.cxf>3.1.16</version.org.apache.cxf>
     <version.org.apache.camel>2.21.1</version.org.apache.camel>
     <version.org.codehaus.cargo>1.6.11</version.org.codehaus.cargo>
     <!-- Custom Freemarker build with workaround for random concurrent access issue (annotation processors). See AF-600 for more info.-->


### PR DESCRIPTION
the version org.apache.cxf was upgraded in jboss-ip-bom to 3.2.5. 
This caused test failures in droolsjbpm-integration/kie-spring-boot.
This commit overrides this version.