### PR TITLE
Fix classifiers after wildfly14 upgrade

### DIFF
--- a/kie-bom/pom.xml
+++ b/kie-bom/pom.xml
@@ -2507,7 +2507,7 @@
         <groupId>org.kie</groupId>
         <artifactId>kie-drools-wb</artifactId>
         <version>${version.org.kie}</version>
-        <classifier>wildfly10</classifier>
+        <classifier>wildfly14</classifier>
         <type>war</type>
       </dependency>
       <dependency>
@@ -2537,7 +2537,7 @@
         <groupId>org.kie</groupId>
         <artifactId>kie-wb</artifactId>
         <version>${version.org.kie}</version>
-        <classifier>wildfly10</classifier>
+        <classifier>wildfly14</classifier>
         <type>war</type>
       </dependency>
       <dependency>
@@ -2551,7 +2551,7 @@
         <groupId>org.kie</groupId>
         <artifactId>kie-wb-monitoring</artifactId>
         <version>${version.org.kie}</version>
-        <classifier>wildfly10</classifier>
+        <classifier>wildfly14</classifier>
         <type>war</type>
       </dependency>
       <dependency>


### PR DESCRIPTION
@adrielparedes this change seems necessary after classifiers have changed in this PR:
https://github.com/kiegroup/kie-wb-distributions/commit/219f9a66bfe2584915e0bfbf7e935919f1c7ca20

Should be merged with:
https://github.com/kiegroup/kie-jenkins-scripts/pull/365
https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/875
https://github.com/kiegroup/jbpm/pull/1366
https://github.com/kiegroup/droolsjbpm-integration/pull/1627
https://github.com/kiegroup/kie-wb-distributions/pull/841