### PR TITLE
added errai for 7.14.x

### DIFF
--- a/script/branch-mapping.yaml
+++ b/script/branch-mapping.yaml
@@ -6,11 +6,14 @@
 master:
   - errai/errai: master
 
+7.14.x:
+  - errai/errai: master
+
 7.11.x:
   - errai/errai: 4.3.x
 
 7.7.x:
-  - errai/errai: master
+  - errai/errai: 4.2.x
 
 7.6.x:
   - errai/errai: 4.1.x


### PR DESCRIPTION
ONLY MERGE this when the 7.14.x is branched
Do this be backported too to 7.14.x?