### PR TITLE
moved com.google.guava and its dependencies to jboss-ip-bom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,6 @@
     <!-- this version will overwrite jboss-ip-bom version 2.5.1. The version in jboss-ip-bom couldn't be upgraded as it will break ModeShape Web Explorer application which uses GWT 2.5.1 -->
     <!-- please look at https://github.com/fredsa/gwt-dnd/wiki/GettingStarted -->
     <version.net.ltgt.gwt.maven>1.0-rc-6</version.net.ltgt.gwt.maven>
-    <version.com.google.guava>20.0</version.com.google.guava>
     <!-- this version will overwrite jboss-ip-version 3.1.2. The version in jboss-ip-bom couldn't be upgraded as this version needs GWT 2.7.0 -->
     <!-- please look at https://github.com/fredsa/gwt-dnd/wiki/GettingStarted -->
     <version.com.allen-sauer.gwt.dnd>3.3.3</version.com.allen-sauer.gwt.dnd>
@@ -2047,11 +2046,6 @@
             <artifactId>javax.annotation-api</artifactId>
           </exclusion>
         </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>com.google.guava</groupId>
-        <artifactId>guava-gwt</artifactId>
-        <version>${version.com.google.guava}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Alignment to JBEAP 7.2
Only merge this when the version of jboss-ip-bom was upgraded to 8.4.0.Final
(https://github.com/jboss-integration/jboss-integration-platform-bom/pull/440)