### PR TITLE
Align JAXB and JAXWS APIs with Wildfly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -248,7 +248,7 @@
 
     <version.org.jboss.spec.javax.websocket>1.1.1.Final</version.org.jboss.spec.javax.websocket>
 
-    <version.javax.xml.soap>1.3.5</version.javax.xml.soap>
+    <version.javax.xml.soap>1.4.0</version.javax.xml.soap>
     <version.javax.jws>1.0-MR1</version.javax.jws>
 
     <version.org.jboss.spec.javax.ws.rs.jboss-jaxrs-api_2.1_spec>1.0.1.Final</version.org.jboss.spec.javax.ws.rs.jboss-jaxrs-api_2.1_spec>
@@ -2698,11 +2698,6 @@
       </dependency>
 
       <dependency>
-        <groupId>javax.xml.bind</groupId>
-        <artifactId>jaxb-api</artifactId>
-        <version>2.3.1</version>
-      </dependency>
-      <dependency>
         <groupId>javax.jws</groupId>
         <artifactId>javax.jws-api</artifactId>
         <version>1.1</version>
@@ -2713,19 +2708,9 @@
         <version>2.3.1</version>
       </dependency>
       <dependency>
-        <groupId>com.sun.xml.ws</groupId>
-        <artifactId>jaxws-tools</artifactId>
-        <version>2.3.1</version>
-      </dependency>
-      <dependency>
         <groupId>javax.annotation</groupId>
         <artifactId>javax.annotation-api</artifactId>
         <version>1.3.2</version>
-      </dependency>
-      <dependency>
-        <groupId>javax.xml.soap</groupId>
-        <artifactId>javax.xml.soap-api</artifactId>
-        <version>1.4.0</version>
       </dependency>
       <dependency>
         <groupId>com.sun.xml.messaging.saaj</groupId>


### PR DESCRIPTION
Depends on https://github.com/jboss-integration/jboss-integration-platform-bom/pull/443. After ip bom of version 8.4.0.Final is released, these kiegroup PRs can be merged once they refer to this new ip bom.


@mbiarnes @mareknovotny here is the alignment of dependencies with Wildfly. They are now using jboss spec 2.3 of jaxb-api and jaxws-api. I have also made some cleaning of dependencies for JDK11. After this has passed and merged, maybe we can push version declarations of these 2 dependencies even to IP BOM, as it is the case now with spec 2.2. But I decided to do it this way first since I am not familiar with any other frontend repositories regarding workbench etc. Maybe jaxb-api and jaxws-api is not even used there.


PR set:

* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/900 (Please comment on this PR if you have any questions)
* https://github.com/kiegroup/droolsjbpm-knowledge/pull/352
* https://github.com/kiegroup/drools/pull/2191
* https://github.com/kiegroup/jbpm/pull/1394
* https://github.com/kiegroup/optaplanner/pull/469
* https://github.com/kiegroup/droolsjbpm-integration/pull/1667
* https://github.com/kiegroup/appformer/pull/574
* https://github.com/kiegroup/optaplanner-wb/pull/319
* https://github.com/kiegroup/jbpm-wb/pull/1257
* https://github.com/kiegroup/kie-wb-distributions/pull/858
* https://github.com/kiegroup/optaweb-employee-rostering/pull/215

