### PR TITLE
replaced hard coded versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -248,7 +248,6 @@
 
     <version.org.jboss.spec.javax.websocket>1.1.1.Final</version.org.jboss.spec.javax.websocket>
 
-    <version.javax.xml.soap>1.3.5</version.javax.xml.soap>
     <version.javax.jws>1.0-MR1</version.javax.jws>
 
     <version.org.jboss.spec.javax.ws.rs.jboss-jaxrs-api_2.1_spec>1.0.1.Final</version.org.jboss.spec.javax.ws.rs.jboss-jaxrs-api_2.1_spec>
@@ -257,13 +256,24 @@
     <version.org.postgresql>9.4.1207</version.org.postgresql>
     <version.mariadb-java-client>1.3.4</version.mariadb-java-client>
 
-    <!-- this versions can be removed once these were migrated to jboss-ip-bom > 8.3.0.Final -->
+    <!-- this versions can be removed once these were migrated to jboss-ip-bom > 8.4.0.Final -->
     <version.org.wildfly>14.0.1.Final</version.org.wildfly>
     <version.org.wildfly.core>6.0.2.Final</version.org.wildfly.core>
 
+    <!-- this versions can be removed once these were migrated to jboss-ip-bom > 8.4.0.Final -->
     <version.org.mvel>2.4.3.Final</version.org.mvel>
     
     <version.ch.obermuhlner>2.0.1</version.ch.obermuhlner>
+
+    <!-- these versions can be removed once these were migrated to jboss-ip-bom > 8.4.0.Final -->
+    <version.javax.xml.bind.jaxb-api>2.3.1</version.javax.xml.bind.jaxb-api>
+    <version.javax.jws.jws-api>1.1</version.javax.jws.jws-api>
+    <version.javax.xml.ws.jaxws-api>2.3.1</version.javax.xml.ws.jaxws-api>
+    <version.com.sun.xml.ws.jaxws-tools>2.3.1</version.com.sun.xml.ws.jaxws-tools>
+    <version.javax.annotation-api>1.3.2</version.javax.annotation-api>
+    <version.javax.xml.soap-api>1.4.0</version.javax.xml.soap-api>
+    <version.com.sun.xml.messaging.saaj>1.5.0</version.com.sun.xml.messaging.saaj>
+
   </properties>
 
   <repositories>
@@ -2626,11 +2636,6 @@
         <artifactId>jsr181-api</artifactId>
         <version>${version.javax.jws}</version>
       </dependency>
-      <dependency>
-        <groupId>javax.xml.soap</groupId>
-        <artifactId>javax.xml.soap-api</artifactId>
-        <version>${version.javax.xml.soap}</version>
-      </dependency>
 
       <dependency>
         <groupId>org.jboss.spec.javax.ws.rs</groupId>
@@ -2700,37 +2705,37 @@
       <dependency>
         <groupId>javax.xml.bind</groupId>
         <artifactId>jaxb-api</artifactId>
-        <version>2.3.1</version>
+        <version>${version.javax.xml.bind.jaxb-api}</version>
       </dependency>
       <dependency>
         <groupId>javax.jws</groupId>
         <artifactId>javax.jws-api</artifactId>
-        <version>1.1</version>
+        <version>${version.javax.jws.jws-api}</version>
       </dependency>
       <dependency>
         <groupId>javax.xml.ws</groupId>
         <artifactId>jaxws-api</artifactId>
-        <version>2.3.1</version>
+        <version>${version.javax.xml.ws.jaxws-api}</version>
       </dependency>
       <dependency>
         <groupId>com.sun.xml.ws</groupId>
         <artifactId>jaxws-tools</artifactId>
-        <version>2.3.1</version>
+        <version>${version.com.sun.xml.ws.jaxws-tools}</version>
       </dependency>
       <dependency>
         <groupId>javax.annotation</groupId>
         <artifactId>javax.annotation-api</artifactId>
-        <version>1.3.2</version>
+        <version>${version.javax.annotation-api}</version>
       </dependency>
       <dependency>
         <groupId>javax.xml.soap</groupId>
         <artifactId>javax.xml.soap-api</artifactId>
-        <version>1.4.0</version>
+        <version>${version.javax.xml.soap-api}</version>
       </dependency>
       <dependency>
         <groupId>com.sun.xml.messaging.saaj</groupId>
         <artifactId>saaj-impl</artifactId>
-        <version>1.5.0</version>
+        <version>${version.com.sun.xml.messaging.saaj}</version>
       </dependency>
       
       <!-- used by DMN for BigDecimal arithmetics -->


### PR DESCRIPTION
All these versions and dependencies will be moved in jboss-ip-bom 8.4.0.Final.
@mariofusco please do not use fixed version in dependencyManagement - better to create a version in <properties> tag and use this.  