### PR TITLE
PLANNER-1328: Make ERRAI-1101 workaround optional

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1407,30 +1407,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
       </plugin>
-
-      <plugin>
-        <artifactId>maven-antrun-plugin</artifactId>
-        <executions>
-          <execution>
-            <!-- Temporary workaround for https://issues.jboss.org/browse/ERRAI-1101. Needs to stay here until
-            we find a general solution (e.g. moving all localized code to Errai TranslationService. -->
-            <id>create-default-i18n-resource</id>
-            <phase>process-resources</phase>
-            <configuration>
-              <target>
-                <copy todir="${project.build.directory}/classes"
-                      includeemptydirs="false" failonerror="false" quiet="true">
-                  <fileset dir="${project.build.directory}/classes"/>
-                  <globmapper from="*Constants.properties" to="*Constants_default.properties"/>
-                </copy>
-              </target>
-            </configuration>
-            <goals>
-              <goal>run</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
   </build>
   <reporting>
@@ -1724,6 +1700,41 @@
             </plugin>
           </plugins>
         </pluginManagement>
+      </build>
+    </profile>
+    <profile>
+      <id>errai-1101</id>
+      <activation>
+        <property>
+          <name>needs-errai-1101-workaround</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <execution>
+                <!-- Temporary workaround for https://issues.jboss.org/browse/ERRAI-1101. Needs to stay here until
+                we find a general solution (e.g. moving all localized code to Errai TranslationService. -->
+                <id>create-default-i18n-resource</id>
+                <phase>process-resources</phase>
+                <configuration>
+                  <target>
+                    <copy todir="${project.build.directory}/classes"
+                          includeemptydirs="false" failonerror="false" quiet="true">
+                      <fileset dir="${project.build.directory}/classes"/>
+                      <globmapper from="*Constants.properties" to="*Constants_default.properties"/>
+                    </copy>
+                  </target>
+                </configuration>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
       </build>
     </profile>
   </profiles>


### PR DESCRIPTION
# PR group:
kiegroup/droolsjbpm-build-bootstrap/pull/908
kiegroup/kie-wb-common/pull/2385
kiegroup/optaplanner-wb/pull/322
kiegroup/jbpm-wb/pull/1271
kiegroup/kie-wb-distributions/pull/861
kiegroup/optaweb-employee-rostering/pull/218

To my understanding, Eclipse's M2Eclipse plugin has difficulties mapping Antrun plugin execution to the build lifecycle. This results in a project configuration error reported to Eclipse IDE users even when working with engine projects (drools, jbpm, optaplanner) where the workaround for [ERRAI-1101](https://issues.jboss.org/browse/ERRAI-1101) isn't needed. To improve the getting started experience for community contributors working in the Eclipse IDE I'm moving the Antrun plugin execution to a profile that's not activated by default.

Projects that use Errai's TranslationService interface and potentially need the workaround can activate the profile with `needs-errai-1101-workaround` property (see other PRs in the group).

You can find out more about the problem with Eclipse and Antrun plugin in [PLANNER-1328](https://issues.jboss.org/browse/PLANNER-1328) where a StackOverflow question with the problem report is linked.