### PR TITLE
upgraded byte buddy because needed by mockito upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -227,7 +227,7 @@
     <version.org.kie.workbench.app>${version.org.kie}</version.org.kie.workbench.app>
 
     <version.org.wildfly.swarm>2018.3.3</version.org.wildfly.swarm>
-    <version.net.byte-buddy>1.8.17</version.net.byte-buddy>
+    <version.net.byte-buddy>1.9.3</version.net.byte-buddy>
     <version.docker-client>3.5.12</version.docker-client>
     <version.kubernetes-client>4.1.0</version.kubernetes-client>
     <version.okhttp>3.8.1</version.okhttp>


### PR DESCRIPTION
Please merge this AFTER the kie reps were upgraded to use jboss-ip-bom 8.4.0.Final
since this has the mockito version 2.23.4 which has dependency to this version of byte-buddy