### PR TITLE
JBPM-8029: Align javaassist for support GwtMockito in Java11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -263,6 +263,7 @@
     <version.javax.annotation-api>1.3.2</version.javax.annotation-api>
     <version.com.sun.xml.messaging.saaj>1.5.0</version.com.sun.xml.messaging.saaj>
 
+    <!-- Remove this property when jboss-ip-bom 8.5.1.Final will be released -->
     <version.org.javassist>3.22.0-GA</version.org.javassist>
 
     <!-- specifal versions to support different version of hibernate for ee7 servers such as WAS and WLS -->

--- a/pom.xml
+++ b/pom.xml
@@ -263,6 +263,8 @@
     <version.javax.annotation-api>1.3.2</version.javax.annotation-api>
     <version.com.sun.xml.messaging.saaj>1.5.0</version.com.sun.xml.messaging.saaj>
 
+    <version.org.javassist>3.22.0-GA</version.org.javassist>
+
     <!-- specifal versions to support different version of hibernate for ee7 servers such as WAS and WLS -->
     <version.org.hibernate-4ee7>5.1.15.Final</version.org.hibernate-4ee7>
     <version.org.jboss.logging-4ee7>3.3.1.Final</version.org.jboss.logging-4ee7>


### PR DESCRIPTION
Hi @romartin, @mareknovotny, @ge0ffrey, @etirelli,

I upgraded JavaAssist dependency to fix GwtMockito issues on Java 11 (see exception below). I tested it on Stunner repository and this error is fixed, let's try FullDonwnstream build to check is it causes any issues.

Thank you!

Version of JavaAssist is set in jboss-integration bom repository, but we can't execute fulldownstream build from it so, not sure should I upgrade it there, or we can override this dependency in this repo.

<details>
  <summary>ClassNotFoundException in GwtMockito</summary>
  <pre>Error Message
caught an exception while obtaining a class file for com.google.gwtmockito.GwtMockito
Stacktrace
java.lang.ClassNotFoundException: caught an exception while obtaining a class file for com.google.gwtmockito.GwtMockito
	at javassist.Loader.findClass(Loader.java:357)
	at com.google.gwtmockito.GwtMockitoTestRunner$GwtMockitoClassLoader.findClass(GwtMockitoTestRunner.java:421)
	at javassist.Loader.loadClass(Loader.java:309)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:521)
	at com.google.gwtmockito.GwtMockitoTestRunner.<init>(GwtMockitoTestRunner.java:148)
	at com.ait.lienzo.test.LienzoMockitoTestRunner.<init>(LienzoMockitoTestRunner.java:47)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:490)
	at org.junit.internal.builders.AnnotatedBuilder.buildRunner(AnnotatedBuilder.java:104)
	at org.junit.internal.builders.AnnotatedBuilder.runnerForClass(AnnotatedBuilder.java:86)
	at org.junit.runners.model.RunnerBuilder.safeRunnerForClass(RunnerBuilder.java:59)
	at org.junit.internal.builders.AllDefaultPossibilitiesBuilder.runnerForClass(AllDefaultPossibilitiesBuilder.java:26)
	at org.junit.runners.model.RunnerBuilder.safeRunnerForClass(RunnerBuilder.java:59)
	at org.junit.internal.requests.ClassRequest.getRunner(ClassRequest.java:33)
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:362)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeWithRerun(JUnit4Provider.java:273)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:238)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:159)
	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:384)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:345)
	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:126)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:418)
Caused by: javassist.NotFoundException: com.google.gwtmockito.GwtMockito
	at javassist.ClassPool.get(ClassPool.java:452)
	at com.ait.lienzo.test.translator.LienzoMockitoClassTranslator.ensureDefrost(LienzoMockitoClassTranslator.java:109)
	at com.ait.lienzo.test.translator.LienzoMockitoClassTranslator.onLoad(LienzoMockitoClassTranslator.java:82)
	at javassist.Loader.findClass(Loader.java:338)
	... 23 more</pre>
</details>