### PR TITLE
BAQE-928 - Change revapi to check against 7.18.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -243,7 +243,7 @@
     <version.org.infinispan>9.4.9.Final</version.org.infinispan>
 
     <!-- Latest release to be used by api-compatibility-check to check backwards compatibility of the Kie API. -->
-    <revapi.oldKieVersion>7.14.0.Final</revapi.oldKieVersion>
+    <revapi.oldKieVersion>7.18.0.Final</revapi.oldKieVersion>
     <revapi.newKieVersion>${project.version}</revapi.newKieVersion>
 
     <version.org.jboss.spec.javax.websocket>1.1.3.Final</version.org.jboss.spec.javax.websocket>


### PR DESCRIPTION
Wait with merge until all valid repositories are good to go.

@rsynek

We now have to check against latest product release (7.3 DM/PAM) which means that we have to check against 7.18.0.Final community release.