### PR TITLE
RHPAM-1549 - Missing translations in the UI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1705,41 +1705,6 @@
         </pluginManagement>
       </build>
     </profile>
-    <profile>
-      <id>errai-1101</id>
-      <activation>
-        <property>
-          <name>needs-errai-1101-workaround</name>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-antrun-plugin</artifactId>
-            <executions>
-              <execution>
-                <!-- Temporary workaround for https://issues.jboss.org/browse/ERRAI-1101. Needs to stay here until
-                we find a general solution (e.g. moving all localized code to Errai TranslationService. -->
-                <id>create-default-i18n-resource</id>
-                <phase>process-resources</phase>
-                <configuration>
-                  <target>
-                    <copy todir="${project.build.directory}/classes"
-                          includeemptydirs="false" failonerror="false" quiet="true">
-                      <fileset dir="${project.build.directory}/classes"/>
-                      <globmapper from="*Constants.properties" to="*Constants_default.properties"/>
-                    </copy>
-                  </target>
-                </configuration>
-                <goals>
-                  <goal>run</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
   </profiles>
 
   <modules>


### PR DESCRIPTION
needs-errai-1101-workaround maven profile added on the below mentioned PR’s seemed to be not applying on all the child maven modules. In this change, needs-errai-1101-workaround maven profile is being removed and  the implementation of the plugin is copied explicitly into all the relevant root project folders which will invoke the plugin for all the child modules.

What Plugin does

It creates a file CONSTANT_DEFAULT.properties for all the properties file we are using, so that in case the translation of a text is not given for a particular language, it uses the CONSTANT_DEFAULT.properties as a fallback for translation.

Please check this for reference

Actual issue: https://issues.jboss.org/browse/ERRAI-1101
Related PR’s:

kiegroup/droolsjbpm-build-bootstrap#729
kiegroup/appformer/pull/267
kiegroup/droolsjbpm-build-bootstrap/pull/729
kiegroup/kie-wb-common/pull/1553
kiegroup/drools-wb/pull/837
kiegroup/jbpm-wb/pull/1026
/pull/268
kiegroup/kie-wb-distributions/pull/720

Related PR's
kiegroup/drools-wb#1142
#336
kiegroup/jbpm-wb#1351
kiegroup/kie-wb-distributions#924
kiegroup/kie-wb-common#2647

