### PR TITLE
upgrade of kie-gwthelper-maven-plugin to the latest 1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
     <!-- this version will overwrite jboss-ip-bom version 2.5.1. The version in jboss-ip-bom couldn't be upgraded as it will break ModeShape Web Explorer application which uses GWT 2.5.1 -->
     <!-- please look at https://github.com/fredsa/gwt-dnd/wiki/GettingStarted -->
     <version.net.ltgt.gwt.maven>1.0-rc-6</version.net.ltgt.gwt.maven>
-    <version.org.kie.gwthelper.maven>1.0</version.org.kie.gwthelper.maven>
+    <version.org.kie.gwthelper.maven>1.1</version.org.kie.gwthelper.maven>
     <!-- this version will overwrite jboss-ip-version 3.1.2. The version in jboss-ip-bom couldn't be upgraded as this version needs GWT 2.7.0 -->
     <!-- please look at https://github.com/fredsa/gwt-dnd/wiki/GettingStarted -->
     <version.com.allen-sauer.gwt.dnd>3.3.3</version.com.allen-sauer.gwt.dnd>


### PR DESCRIPTION
This is an upgrade https://github.com/kiegroup/kie-gwthelper-maven-plugin/releases/tag/1.1  which fixes to have correct content for kie-gwthelper-maven-plugin when @gitgabrio externalized the plugin into individual repository.
This is not depending on any parent or dependency hierarchy from kiegroup repositories.

