### PR TITLE
DROOLS-4049: PMML files are not listed in Library only in Project Explorer

### DIFF
--- a/drools-bom/pom.xml
+++ b/drools-bom/pom.xml
@@ -1160,6 +1160,30 @@
         <version>${version.org.kie}</version>
         <classifier>sources</classifier>
       </dependency>
+      <!--DRL Text Editor-->
+      <dependency>
+        <groupId>org.drools</groupId>
+        <artifactId>drools-wb-pmml-text-editor-api</artifactId>
+        <version>${version.org.kie}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.drools</groupId>
+        <artifactId>drools-wb-pmml-text-editor-api</artifactId>
+        <version>${version.org.kie}</version>
+        <classifier>sources</classifier>
+      </dependency>
+      <dependency>
+        <groupId>org.drools</groupId>
+        <artifactId>drools-wb-pmml-text-editor-client</artifactId>
+        <version>${version.org.kie}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.drools</groupId>
+        <artifactId>drools-wb-pmml-text-editor-client</artifactId>
+        <version>${version.org.kie}</version>
+        <classifier>sources</classifier>
+      </dependency>
+
       <!--REST-->
 
       <!--drools-wb distribution-->


### PR DESCRIPTION
See https://issues.jboss.org/browse/DROOLS-4049

This PR contains GAV declarations for a _basic_ PMML editor.