### PR TITLE
[AF-1792]  Migration of space information from system.git to config.git + HA improvements

### DIFF
--- a/kie-bom/pom.xml
+++ b/kie-bom/pom.xml
@@ -1695,6 +1695,11 @@
         <artifactId>kie-wb-common-cli-system-configuration-migration</artifactId>
         <version>${version.org.kie}</version>
       </dependency>
+      <dependency>
+        <groupId>org.kie.workbench</groupId>
+        <artifactId>kie-wb-common-cli-system-to-space-configuration-migration</artifactId>
+        <version>${version.org.kie}</version>
+      </dependency>
 
       <!-- Forms -->
       <dependency>


### PR DESCRIPTION
# AF-1792

## Description

Several things happen in this PR that can't be split in several commits:

### Migration from system.git to config.git

All the information about spaces and repositories used to live in system.git project. That project makes that every change that was need to be done locks repository for all users. 
Now, all the information about each space is stored inside config.git in every space. So lock will happen only for that space and not for the whole file system. Also migration tool was modified to include previous changes.

### Logical Deletion

When you delete a Space or Repository, they are marked to be deleted. User will continue working as it was used to. Nothing from user perspectiva but they way that deleted spaces are shown. 
* A deleted Repository disappear from Library View and is marked to be deleted with a flag in config.git
* A deleted Space doesn't disappear from Spaces View but users can't get into that Space. In the UI the space is marked to be deleted. Also is marked to be deleted with a flag in config.git.

### Physical Deletion

Every one minute a FileSystemDeleteWorker runs to delete all the repositories and spaces that are marked to be deleted. This runs in all nodes, but only one will be able to execute those operations.

### HA Improvements

Many events where added to improve HA experience. Also visual improvements to show correct assets/spaces/repositories/contributors counters and deleted spaces right identification.

### RHSSO

RHSSO configuration was included to let BC consume contributors from SSO List.

## Collaborators

* Paulo Rego
* Pere Fernandez Pere
* Eder Ignatowicz
* Adriel Paredes

## PRs related

* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/970
* https://github.com/kiegroup/appformer/pull/715
* https://github.com/kiegroup/kie-wb-common/pull/2692
* https://github.com/kiegroup/jbpm-wb/pull/1362
* https://github.com/kiegroup/kie-wb-distributions/pull/936

