### PR TITLE
RHPAM-1873: upgrade of cxf to 3.2.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -370,7 +370,7 @@
     <version.net.sf.docbook.docbook-xsl>1.76.1</version.net.sf.docbook.docbook-xsl>
     <version.org.antlr4>4.7.2</version.org.antlr4>
     <!-- overrides version of cxf coming from jboss-ip-bom 8.3.2.Final since tests in kie-spring-boot (droolsjbpm-integration) fail -->
-    <version.org.apache.cxf>3.1.16</version.org.apache.cxf>
+    <version.org.apache.cxf>3.2.5</version.org.apache.cxf>
     <version.org.apache.camel>2.24.0</version.org.apache.camel>
     <version.org.codehaus.cargo>1.7.1</version.org.codehaus.cargo>
     <!-- Custom Freemarker build with workaround for random concurrent access issue (annotation processors). See AF-600 for more info.-->


### PR DESCRIPTION
Change-Id: Ic16e566d6703420c168050c48367f68a0a8ea72f

Repeating https://github.com/jboss-integration/jboss-integration-platform-bom/pull/444 to current kie-parent
https://issues.jboss.org/browse/RHPAM-1873