### PR TITLE
BAQE-1001 Unify reporting to SonarCloud under KIE parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1702,6 +1702,11 @@
           <artifactId>wildfly-maven-plugin</artifactId>
           <version>1.2.0.Final</version>
         </plugin>
+        <plugin>
+          <groupId>org.sonarsource.scanner.maven</groupId>
+          <artifactId>sonar-maven-plugin</artifactId>
+          <version>3.6.0.1398</version>
+        </plugin>
       </plugins>
     </pluginManagement>
 
@@ -2043,6 +2048,86 @@
           </plugins>
         </pluginManagement>
       </build>
+    </profile>
+    <!-- Merges test coverage reports and uploads statistics via sonar scanner into the SonarCloud. -->
+    <profile>
+      <id>sonarcloud-analysis</id>
+      <properties>
+        <!--suppress UnresolvedMavenProperty -->
+        <jacoco.master.exec.file>${maven.multiModuleProjectDirectory}/target/jacoco.exec</jacoco.master.exec.file>
+        <sonar.jacoco.reportPaths>${jacoco.master.exec.file}</sonar.jacoco.reportPaths>
+        <sonar.host.url>https://sonarcloud.io</sonar.host.url>
+        <sonar.organization>kiegroup</sonar.organization>
+        <!--suppress UnresolvedMavenProperty -->
+        <sonar.login>${env.SONARCLOUD_TOKEN}</sonar.login>
+      </properties>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.jacoco</groupId>
+              <artifactId>jacoco-maven-plugin</artifactId>
+              <configuration>
+                <fileSets>
+                  <fileSet>
+                    <directory>${project.build.directory}</directory>
+                    <includes>
+                      <include>*.exec</include>
+                    </includes>
+                  </fileSet>
+                </fileSets>
+                <destFile>${jacoco.master.exec.file}</destFile>
+              </configuration>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+        <plugins>
+          <plugin>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>report</goal>
+                  <goal>merge</goal>
+                </goals>
+                <phase>generate-resources</phase>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.sonarsource.scanner.maven</groupId>
+            <artifactId>sonar-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>sonar</goal>
+                </goals>
+                <phase>generate-resources</phase>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>sonarcloud-analysis-pull-request</id>
+      <activation>
+        <property>
+          <name>env.ghprbPullId</name>
+        </property>
+      </activation>
+      <properties>
+        <sonar.pullrequest.provider>GitHub</sonar.pullrequest.provider>
+        <!--suppress UnresolvedMavenProperty -->
+        <sonar.pullrequest.branch>${env.ghprbSourceBranch}</sonar.pullrequest.branch>
+        <!--suppress UnresolvedMavenProperty -->
+        <sonar.pullrequest.key>${env.ghprbPullId}</sonar.pullrequest.key>
+        <!--suppress UnresolvedMavenProperty -->
+        <sonar.pullrequest.base>${env.ghprbTargetBranch}</sonar.pullrequest.base>
+        <!--suppress UnresolvedMavenProperty -->
+        <sonar.pullrequest.github.repository>${env.ghprbAuthorRepoGitUrl}</sonar.pullrequest.github.repository>
+      </properties>
     </profile>
   </profiles>
 

--- a/pom.xml
+++ b/pom.xml
@@ -2125,8 +2125,6 @@
         <sonar.pullrequest.key>${env.ghprbPullId}</sonar.pullrequest.key>
         <!--suppress UnresolvedMavenProperty -->
         <sonar.pullrequest.base>${env.ghprbTargetBranch}</sonar.pullrequest.base>
-        <!--suppress UnresolvedMavenProperty -->
-        <sonar.pullrequest.github.repository>${env.ghprbAuthorRepoGitUrl}</sonar.pullrequest.github.repository>
       </properties>
     </profile>
   </profiles>


### PR DESCRIPTION
- jacoco:report, jacoco:merge and sonar:sonar are configured in pom.xml instead of triggering them directly
- sonarcloud-related properties are read from environment variables that are set by Jenkins
- PR analysis is moved to a separate profile