### PR TITLE
fixed update script and kie-createReleaseBranches.sh

### DIFF
--- a/script/release/kie-createReleaseBranches.sh
+++ b/script/release/kie-createReleaseBranches.sh
@@ -40,23 +40,9 @@ fi
 ./droolsjbpm-build-bootstrap/script/release/update-version-all.sh $releaseVersion $uberfireVersion custom
 
 
-# change properties via sed as they don't update automatically
-#appformer
-cd appformer
-sed -i \
--e "$!N;s/<version.org.kie>.*.<\/version.org.kie>/<version.org.kie>$releaseVersion<\/version.org.kie>/;" \
--e "s/<version.org.jboss.errai>.*.<\/version.org.jboss.errai>/<version.org.jboss.errai>$erraiVersion<\/version.org.jboss.errai>/;P;D" \
-pom.xml
-cd ..
-
 #droolsjbpm-build-bootstrap
 cd droolsjbpm-build-bootstrap/
-sed -i \
--e "$!N;s/<version.org.uberfire>.*.<\/version.org.uberfire>/<version.org.uberfire>$uberfireVersion<\/version.org.uberfire>/;" \
--e "s/<version.org.kie>.*.<\/version.org.kie>/<version.org.kie>$releaseVersion<\/version.org.kie>/;" \
--e "s/<version.org.jboss.errai>.*.<\/version.org.jboss.errai>/<version.org.jboss.errai>$erraiVersion<\/version.org.jboss.errai>/;" \
--e "s/<latestReleasedVersionFromThisBranch>.*.<\/latestReleasedVersionFromThisBranch>/<latestReleasedVersionFromThisBranch>$releaseVersion<\/latestReleasedVersionFromThisBranch>/;P;D" \
-pom.xml
+sed -i "s/<latestReleasedVersionFromThisBranch>.*.<\/latestReleasedVersionFromThisBranch>/<latestReleasedVersionFromThisBranch>$releaseVersion<\/latestReleasedVersionFromThisBranch>/" pom.xml
 cd ..
 
 # git add and commit the version update changes 


### PR DESCRIPTION
version upgrades that doesn't update automatically and have to be changed "manually" now are changed directly in the update-version-all.sh script - so this is not needed any more in kie-createReleaseBranches.sh  script

With these changes the update of versions work:
- it respects the new kie-soup-bom and uberfire-bom in droolsjbpm-build-bootstrap
- is respects the own version number of uberfire