### PR TITLE
Return failsafe plugin back to default plugin executions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1744,6 +1744,10 @@
         <groupId>org.jboss.maven.plugins</groupId>
         <artifactId>maven-jdocbook-plugin</artifactId>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
   <reporting>


### PR DESCRIPTION
Failsafe plugin was unintentionally removed in https://github.com/kiegroup/droolsjbpm-build-bootstrap/commit/fc094e3b4d14edde0a09c4de95f01ee5e8902326#diff-600376dffeb79835ede4a0b285078036L1415 .
The result is that majority of integration tests were not executed since then.