### PR TITLE
DROOLS-4302: security vulnerability:update of org.springframework

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -312,7 +312,7 @@
     <version.org.sonatype.plexus.plexus-sec-dispatcher>1.3</version.org.sonatype.plexus.plexus-sec-dispatcher>
     <version.org.sonatype.sisu>2.3.0</version.org.sonatype.sisu>
     <version.org.sonatype.sisu.sisu-guice>3.2.3</version.org.sonatype.sisu.sisu-guice>
-    <version.org.springframework>4.3.3.RELEASE</version.org.springframework>
+    <version.org.springframework>4.3.24.RELEASE</version.org.springframework>
     <version.org.springframework.osgi>1.2.1</version.org.springframework.osgi>
     <version.org.subethamail>1.2</version.org.subethamail>
     <version.org.subethamail.subethasmtp>3.1.6</version.org.subethamail.subethasmtp>


### PR DESCRIPTION
first step: upgrade to 4.3.18.RELEASE
second step: upgrade to 5.1.3.RELEASE (see https://issues.jboss.org/browse/DROOLS-4302)