### PR TITLE
added exclusion for banned dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4467,6 +4467,12 @@
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs</artifactId>
         <version>${version.org.jboss.resteasy}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.jboss.resteasy</groupId>


### PR DESCRIPTION
kieAllBuild-master failed because of 
22:53:16 [WARNING] Rule 0: org.apache.maven.plugins.enforcer.BannedDependencies failed with message:
22:53:16 Found Banned Dependency: commons-logging:commons-logging:jar:1.1.1
22:53:16 Use 'mvn dependency:tree' to locate the source of the banned dependencies

commons-logging is brought in as transitive dependency from resteasy-jaxrs.
