### PR TITLE
RHPAM-2036 :Group cannot be added in Business central integrated with…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -285,7 +285,7 @@
     <version.org.json>20090211</version.org.json>
     <version.org.jsoup>1.8.3</version.org.jsoup>
     <version.org.jvnet.mock-javamail>1.9</version.org.jvnet.mock-javamail>
-    <version.org.keycloak>1.9.4.Final</version.org.keycloak>
+    <version.org.keycloak>4.8.3.Final</version.org.keycloak>
     <version.org.littleshoot.littleproxy>0.5.3</version.org.littleshoot.littleproxy>
     <version.log4j>1.2.17</version.log4j>
     <version.ognl>3.0.6</version.ognl>


### PR DESCRIPTION
… RHSSO integration

- Upgraded keycloak version to 4.8.3.
- This version of keycloak is same as used by RH-SSO 7.3. It is also compatible with RH-SSO 7.2.
- The error message was displayed since method "setScopeParamRequired" is no longer present in keycloak version 4.8.3.
- linked PR- https://github.com/kiegroup/appformer/pull/743