### PR TITLE
Further automate revapi cleaning

### DIFF
--- a/script/utils/revapi-clean.sh
+++ b/script/utils/revapi-clean.sh
@@ -1,4 +1,19 @@
 #!/bin/sh
+# How to clean ignores in revapi-config.json files:
+#
+# export REVAPI_REPOSITORIES=droolsjbpm-build-bootstrap,droolsjbpm-knowledge,drools,jbpm,droolsjbpm-integration,optaplanner
+#
+# ./git-clone-others.sh --repo-list=$REVAPI_REPOSITORIES --add-upstream-remote
+# ./git-all.sh --repo-list=$REVAPI_REPOSITORIES checkout master
+# ./git-all.sh --repo-list=$REVAPI_REPOSITORIES pull --rebase upstream master
+# ./git-all.sh --repo-list=$REVAPI_REPOSITORIES checkout -b revapi-7.23.0.Final
+# Copy this script to root of all repositories and run it there, ./revapi-clean.sh 7.23.0.Final
+# Update <revapi.oldKieVersion> in kie-parent
+# ./mvn-all.sh --repo-list=$REVAPI_REPOSITORIES clean install -DskipTests
+# ./git-all.sh --repo-list=$REVAPI_REPOSITORIES add -u
+# ./git-all.sh --repo-list=$REVAPI_REPOSITORIES commit -m "BAQE-1039 - Change revapi to check against 7.23.0.Final"
+# ./git-all.sh --repo-list=$REVAPI_REPOSITORIES push origin revapi-7.23.0.Final
+# Create PRs
 # Utility script for removing ignores in revapi-config.json files.
 
 usage ()


### PR DESCRIPTION
@mbiarnes I have added 2 new options to the git-clone-others.sh file:

* Ability to run it only on a subset of repositories using either `--repo-list=` or `--target-repo=` option. Now it is aligned with other scripts like git-all.sh and mvn-all.sh. *.bat versions lack these parameters, so I decided to not add it to the git-clone-others.bat either.
* I have added `--add-upstream-remote` option so repositories can be cloned and an upstream remote is added (kiegroup) which might be handy in case there is a need to pull the newest upstream changes and rebase on that, for example when creating a PR.

I really have no idea what the `--target-repo=` option is for, so I just wanted to ask.
And please double check it if I didn't break anything. But it should be backward compatible.
