### PR TITLE
changed uberfire-bom version to KIE version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5499,7 +5499,7 @@
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-bom</artifactId>
         <type>pom</type>
-        <version>${version.org.uberfire}</version>
+        <version>${version.org.kie}</version>
         <scope>import</scope>
       </dependency>
       <dependency>

--- a/script/release/update-version-all.sh
+++ b/script/release/update-version-all.sh
@@ -116,7 +116,7 @@ for repository in `cat ${scriptDir}/../repository-list.txt` ; do
             # extract old kie version
             kieOldVersion=$(grep -oP -m 2 '(?<=<version>).*(?=</version)' pom.xml| awk 'FNR==2')
             # extract old uberfire version
-            oldUberfireVersion=$(grep -oP -m 2 '(?<=<version>).*(?=</version)' uberfire-bom/pom.xml | awk 'FNR==2')
+            oldUberfireVersion=$(grep -oP -m 2 '(?<=<version.org.uberfire>).*(?=</version.org.uberfire)' uberfire-bom/pom.xml | awk 'FNR==2')
             newUberfireVersion=$2
             mvnVersionsSet
             # update latest released version property only for non-SNAPSHOT versions
@@ -130,7 +130,8 @@ for repository in `cat ${scriptDir}/../repository-list.txt` ; do
             # update version that are not automatically updated
             sed -i "s/<version.org.kie>$kieOldVersion<\/version.org.kie>/<version.org.kie>$newVersion<\/version.org.kie>/" pom.xml
             sed -i "s/<version.org.uberfire>$oldUberfireVersion<\/version.org.uberfire>/<version.org.uberfire>$newUberfireVersion<\/version.org.uberfire>/" pom.xml
-            sed -i "s/<version>$oldUberfireVersion<\/version>/<version>$newUberfireVersion<\/version>/" uberfire-bom/pom.xml
+            sed -i "s/<version>$kieOldVersion<\/version>/<version>$newVersion<\/version>/" uberfire-bom/pom.xml
+            sed -i "s/<version.org.uberfire>$oldUberfireVersion<\/version.org.uberfire>/<version.org.uberfire>$newUberfireVersion<\/version.org.uberfire>/" uberfire-bom/pom.xml
             # workaround for http://jira.codehaus.org/browse/MVERSIONS-161
             mvn -B -s $settingsXmlFile clean install -DskipTests
             returnCode=$?

--- a/uberfire-bom/pom.xml
+++ b/uberfire-bom/pom.xml
@@ -28,7 +28,6 @@
 
   <groupId>org.uberfire</groupId>
   <artifactId>uberfire-bom</artifactId>
-  <version>2.22.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>UberFire BOM (Bill Of Materials)</name>
@@ -57,6 +56,10 @@
     <system>jira</system>
     <url>https://issues.jboss.org/browse/UF</url>
   </issueManagement>
+
+  <properties>
+    <version.org.uberfire>2.22.0-SNAPSHOT</version.org.uberfire>
+  </properties>
 
   <repositories>
     <!-- Bootstrap repository to locate the parent pom in case it has not yet been synced in Maven Central. -->
@@ -93,7 +96,7 @@
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-webapp</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <type>war</type>
       </dependency>
 
@@ -101,12 +104,12 @@
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-server</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-server</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
@@ -114,45 +117,45 @@
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-security-api</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-security-api</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-security-client</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-security-client</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-security-client-backend</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-security-client-backend</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-security-codegen</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-security-codegen</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
@@ -160,34 +163,34 @@
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-backend-api</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-backend-api</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-backend-server</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-backend-server</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-backend-cdi</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-backend-cdi</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
@@ -195,90 +198,90 @@
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-api</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-api</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-client-api</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-client-api</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-workbench-client</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-workbench-client</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-workbench-client-views-patternfly</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-workbench-client-views-patternfly</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-workbench-client-backend</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-workbench-client-backend</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-workbench-processors</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-workbench-processors</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-workbench-processors-tests</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-workbench-processors-tests</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
       <!-- JS Native Plugins -->
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-js</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-js</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
@@ -286,29 +289,29 @@
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-commons</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-commons</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-io</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-io</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-io</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <type>test-jar</type>
       </dependency>
 
@@ -316,45 +319,45 @@
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-nio2-model</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-nio2-model</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-nio2-api</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-nio2-api</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-nio2-fs</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-nio2-fs</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-nio2-jgit</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-nio2-jgit</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
@@ -362,32 +365,32 @@
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-ssh-api</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-ssh-api</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-ssh-backend</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-ssh-client</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-ssh-client</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
@@ -395,63 +398,63 @@
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-client</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-client</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-client-backend</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-client-backend</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-client-all</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-client-all</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-server-all</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-all</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-all</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <!-- Testing Utils -->
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-testing-utils</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-testing-utils</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
@@ -460,53 +463,53 @@
         <groupId>org.uberfire</groupId>
         <artifactId>showcase-distribution-wars</artifactId>
         <type>war</type>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>tomcat7.0</classifier>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>showcase-distribution-wars</artifactId>
         <type>war</type>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>wildfly8.1</classifier>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-apps-api</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-apps-api</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-apps-backend</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-apps-backend</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-apps-client</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-apps-client</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
@@ -515,39 +518,39 @@
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-layout-editor-api</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-layout-editor-api</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-layout-editor-backend</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-layout-editor-backend</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-layout-editor-client</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-layout-editor-client</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
@@ -557,65 +560,65 @@
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-metadata-api</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-metadata-api</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-metadata-backend-lucene</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-metadata-backend-lucene</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-metadata-backend-elasticsearch</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-metadata-backend-elasticsearch</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-metadata-backend-infinispan</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-metadata-backend-infinispan</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-metadata-commons-io</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-metadata-commons-io</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
@@ -624,39 +627,39 @@
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-commons-editor-api</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-commons-editor-api</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-commons-editor-backend</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-commons-editor-backend</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-commons-editor-client</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-commons-editor-client</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
@@ -665,78 +668,78 @@
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-preferences-api</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-preferences-api</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-preferences-backend</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-preferences-backend</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-preferences-client</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-preferences-client</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-preferences-client-backend</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-preferences-client-backend</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-preferences-ui-client</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-preferences-ui-client</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-preferences-processors</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-preferences-processors</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
@@ -745,39 +748,39 @@
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-runtime-plugins-api</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-runtime-plugins-api</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-runtime-plugins-backend</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-runtime-plugins-backend</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-runtime-plugins-client</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-runtime-plugins-client</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
@@ -786,13 +789,13 @@
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-servlet-security</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-servlet-security</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
@@ -801,85 +804,85 @@
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-security-management-api</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-security-management-api</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-security-management-backend</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-security-management-backend</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-security-management-backend</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <type>test-jar</type>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-security-management-client</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-security-management-client</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-security-management-keycloak</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-security-management-keycloak</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-security-management-wildfly</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-security-management-wildfly</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-security-management-tomcat</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-security-management-tomcat</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
@@ -888,52 +891,52 @@
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-widgets-commons</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-widgets-commons</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-widgets-service-api</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-widgets-service-api</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-widgets-service-backend</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-widgets-service-backend</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-widgets-table</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-widgets-table</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
@@ -942,13 +945,13 @@
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-widgets-core-client</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-widgets-core-client</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
@@ -957,13 +960,13 @@
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-widget-markdown</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-widget-markdown</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
@@ -972,39 +975,39 @@
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-widgets-properties-editor-api</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-widgets-properties-editor-api</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-widgets-properties-editor-backend</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-widgets-properties-editor-backend</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-widgets-properties-editor-client</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-widgets-properties-editor-client</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
@@ -1013,39 +1016,39 @@
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-widgets-security-management</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-widgets-security-management</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-security-management-client-wb</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-security-management-client-wb</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-security-management-webapp</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-security-management-webapp</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
@@ -1054,32 +1057,32 @@
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-experimental-api</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-experimental-api</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-experimental-backend</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-experimental-client</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-experimental-client</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
@@ -1088,156 +1091,156 @@
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-wires-bayesian-network-client</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-wires-bayesian-network-client</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-wires-bayesian-parser-api</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-wires-bayesian-parser-api</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-wires-bayesian-parser-backend</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-wires-bayesian-parser-backend</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-wires-core-api</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-wires-core-api</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-wires-core-client</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-wires-core-client</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-wires-core-scratchpad</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-wires-core-scratchpad</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-wires-core-trees</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-wires-core-trees</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-wires-core-grids</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-wires-core-grids</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-wires-webapp</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-wires-webapp</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-wires-bpmn-api</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-wires-bpmn-api</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-wires-bpmn-backend</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-wires-bpmn-backend</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-wires-bpmn-client</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-wires-bpmn-client</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
@@ -1245,12 +1248,12 @@
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-simple-docks-client</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-simple-docks-client</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
@@ -1258,179 +1261,179 @@
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-m2repo-editor-api</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-m2repo-editor-api</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-m2repo-editor-backend</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-message-console-api</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-message-console-api</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-project-api</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-project-api</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-project-backend</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-project-builder</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-project-client</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-project-client</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-rest-backend</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-rest-client</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-rest-client</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-services-api</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-services-api</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-services-backend</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-structure-api</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-structure-api</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-structure-backend</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-structure-client</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-structure-client</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-structure-client</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>tests</classifier>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-test-utils</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-workingset-api</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-workingset-api</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-m2repo-editor-client</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-m2repo-editor-client</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-message-console-backend</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-message-console-client</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-message-console-client</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-workingset-client</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-workingset-client</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
@@ -1438,39 +1441,39 @@
       <dependency>
         <groupId>org.dashbuilder</groupId>
         <artifactId>dashbuilder-displayer-api</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.dashbuilder</groupId>
         <artifactId>dashbuilder-displayer-api</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
       <dependency>
         <groupId>org.dashbuilder</groupId>
         <artifactId>dashbuilder-navigation-api</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.dashbuilder</groupId>
         <artifactId>dashbuilder-navigation-api</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
       <dependency>
         <groupId>org.dashbuilder</groupId>
         <artifactId>dashbuilder-services-api</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.dashbuilder</groupId>
         <artifactId>dashbuilder-services-api</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
@@ -1478,13 +1481,13 @@
       <dependency>
         <groupId>org.dashbuilder</groupId>
         <artifactId>dashbuilder-validations</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.dashbuilder</groupId>
         <artifactId>dashbuilder-validations</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
@@ -1492,39 +1495,39 @@
       <dependency>
         <groupId>org.dashbuilder</groupId>
         <artifactId>dashbuilder-dataset-cdi</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.dashbuilder</groupId>
         <artifactId>dashbuilder-dataset-cdi</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
       <dependency>
         <groupId>org.dashbuilder</groupId>
         <artifactId>dashbuilder-navigation-backend</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.dashbuilder</groupId>
         <artifactId>dashbuilder-navigation-backend</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
       <dependency>
         <groupId>org.dashbuilder</groupId>
         <artifactId>dashbuilder-services</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.dashbuilder</groupId>
         <artifactId>dashbuilder-services</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
@@ -1533,170 +1536,170 @@
       <dependency>
         <groupId>org.dashbuilder</groupId>
         <artifactId>dashbuilder-common-client</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.dashbuilder</groupId>
         <artifactId>dashbuilder-common-client</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
       <dependency>
         <groupId>org.dashbuilder</groupId>
         <artifactId>dashbuilder-dataset-client</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.dashbuilder</groupId>
         <artifactId>dashbuilder-dataset-client</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
       <dependency>
         <groupId>org.dashbuilder</groupId>
         <artifactId>dashbuilder-dataset-client</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <type>test-jar</type>
       </dependency>
 
       <dependency>
         <groupId>org.dashbuilder</groupId>
         <artifactId>dashbuilder-displayer-client</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.dashbuilder</groupId>
         <artifactId>dashbuilder-displayer-client</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
       <dependency>
         <groupId>org.dashbuilder</groupId>
         <artifactId>dashbuilder-displayer-client</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <type>test-jar</type>
       </dependency>
 
       <dependency>
         <groupId>org.dashbuilder</groupId>
         <artifactId>dashbuilder-displayer-screen</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.dashbuilder</groupId>
         <artifactId>dashbuilder-displayer-screen</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
       <dependency>
         <groupId>org.dashbuilder</groupId>
         <artifactId>dashbuilder-displayer-editor</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.dashbuilder</groupId>
         <artifactId>dashbuilder-displayer-editor</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
       <dependency>
         <groupId>org.dashbuilder</groupId>
         <artifactId>dashbuilder-dataset-editor</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.dashbuilder</groupId>
         <artifactId>dashbuilder-dataset-editor</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
       <dependency>
         <groupId>org.dashbuilder</groupId>
         <artifactId>dashbuilder-renderer-lienzo</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.dashbuilder</groupId>
         <artifactId>dashbuilder-renderer-lienzo</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
       <dependency>
         <groupId>org.dashbuilder</groupId>
         <artifactId>dashbuilder-renderer-default</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.dashbuilder</groupId>
         <artifactId>dashbuilder-renderer-default</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
       <dependency>
         <groupId>org.dashbuilder</groupId>
         <artifactId>dashbuilder-renderer-c3</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
       <dependency>
         <groupId>org.dashbuilder</groupId>
         <artifactId>dashbuilder-renderer-c3</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.dashbuilder</groupId>
         <artifactId>dashbuilder-widgets</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.dashbuilder</groupId>
         <artifactId>dashbuilder-widgets</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
       <dependency>
         <groupId>org.dashbuilder</groupId>
         <artifactId>dashbuilder-navigation-client</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.dashbuilder</groupId>
         <artifactId>dashbuilder-navigation-client</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
       <dependency>
         <groupId>org.dashbuilder</groupId>
         <artifactId>dashbuilder-cms-client</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.dashbuilder</groupId>
         <artifactId>dashbuilder-cms-client</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
@@ -1705,13 +1708,13 @@
       <dependency>
         <groupId>org.dashbuilder</groupId>
         <artifactId>dashbuilder-renderer-chartjs</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.dashbuilder</groupId>
         <artifactId>dashbuilder-renderer-chartjs</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
@@ -1719,39 +1722,39 @@
       <dependency>
         <groupId>org.dashbuilder</groupId>
         <artifactId>dashbuilder-client-all</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.dashbuilder</groupId>
         <artifactId>dashbuilder-client-all</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
       <dependency>
         <groupId>org.dashbuilder</groupId>
         <artifactId>dashbuilder-server-all</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.dashbuilder</groupId>
         <artifactId>dashbuilder-server-all</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
       <dependency>
         <groupId>org.dashbuilder</groupId>
         <artifactId>dashbuilder-all</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.dashbuilder</groupId>
         <artifactId>dashbuilder-all</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
@@ -1759,27 +1762,27 @@
       <dependency>
         <groupId>org.dashbuilder</groupId>
         <artifactId>dashbuilder-webapp</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <type>war</type>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>appformer-js-bridge</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>appformer-js-bridge</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
         <classifier>sources</classifier>
       </dependency>
 
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>appformer-js</artifactId>
-        <version>${project.version}</version>
+        <version>${version.org.uberfire}</version>
       </dependency>
 
     </dependencies>


### PR DESCRIPTION
The commit https://github.com/kiegroup/droolsjbpm-build-bootstrap/commit/34dfe2ec1c3634a0d06db0b16f49b57e5e085301 moved uberfire-bom from appformer into droolsjbpm-build-bootstrap, with uberfire-bom version kept as Appformer version. Since this is not very user-friendly and breaks product build, this PR proposes a change of uberfire-bom version to KIE version to align it with the rest of the BOMs.

Related PRs: 
- https://github.com/kiegroup/appformer/pull/746
- https://github.com/kiegroup/droolsjbpm-integration/pull/1873
- https://github.com/kiegroup/drools-wb/pull/1198
- https://github.com/kiegroup/jbpm-designer/pull/856
- https://github.com/kiegroup/jbpm-wb/pull/1375
- https://github.com/kiegroup/kie-uberfire-extensions/pull/87
- https://github.com/kiegroup/kie-wb-common/pull/2780
- https://github.com/kiegroup/kie-wb-distributions/pull/947
- https://github.com/kiegroup/optaplanner-wb/pull/342