### PR TITLE
Move hacep repo after droolsjbpm-integration

### DIFF
--- a/script/repository-list.txt
+++ b/script/repository-list.txt
@@ -5,11 +5,11 @@ kie-soup
 appformer
 droolsjbpm-knowledge
 drools
-openshift-drools-hacep
 optaplanner
 jbpm
 kie-jpmml-integration
 droolsjbpm-integration
+openshift-drools-hacep
 droolsjbpm-tools
 kie-uberfire-extensions
 kie-wb-playground


### PR DESCRIPTION
This change is needed because openshift-drools-hacep requires kie-maven-plugin which is located in droolsjbpm-integration repository.