### PR TITLE
Add exclusion of org.apache.kafka.common.message.* classes to duplicated class check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -864,6 +864,9 @@
                       <ignoreClass>org.infinispan.util.AbstractDelegatingMap</ignoreClass>
                       <ignoreClass>org.infinispan.util.AbstractDelegatingSet</ignoreClass>
                       <ignoreClass>org.infinispan.util.AbstractDelegatingCollection</ignoreClass>
+                      <!-- This package contains auto generated code and is available both in kafka-clients
+                      and in kafka-clients-test -->
+                      <ignoreClass>org.apache.kafka.common.message.*</ignoreClass>
                     </ignoreClasses>
                     <dependencies>
                       <!-- gwt-dev bundles dozens of different 3rd party dependencies, but can not be usually excluded


### PR DESCRIPTION
All classes in `org.apache.kafka.common.message` package are autogenerated and duplicated. They are available in both `kafka-clients` and `kafka-clients-test` artifact.
Hacep integration tests module use both so the build fails

@jiripetrlik @desmax74 @mbiarnes @mareknovotny  