### PR TITLE
Upgrade H2 database to latest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
     <version.com.google.javascript.closure-compiler>r1741</version.com.google.javascript.closure-compiler>
     <version.com.google.jsinterop>1.0.1</version.com.google.jsinterop>
     <version.com.google.protobuf>3.6.1</version.com.google.protobuf>
-    <version.com.h2database>1.3.173</version.com.h2database>
+    <version.com.h2database>1.4.199</version.com.h2database>
     <version.com.jcraft>0.1.54</version.com.jcraft>
     <version.com.lowagie.itext>2.1.7</version.com.lowagie.itext>
     <version.com.mchange.c3p0>0.9.5.2</version.com.mchange.c3p0>


### PR DESCRIPTION
- 1.3.173 is from 07/2013 (6 years old).

- 1.4.199 is used by current Spring Boot.

- 1.4.x changelog: http://www.h2database.com/html/changelog.html