### PR TITLE
BAQE-1049 Measure cross-module test coverage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -537,6 +537,10 @@
     <version.io.prometheus>0.5.0</version.io.prometheus>
     <version.com.github.javaparser>3.13.10</version.com.github.javaparser>
 
+    <!-- JaCoCo coverage data file location. Using a single file for appending in the project's root directory makes it
+         possible to measure cross-module test coverage -->
+    <!--suppress UnresolvedMavenProperty -->
+    <jacoco.exec.file>${maven.multiModuleProjectDirectory}/target/jacoco.exec</jacoco.exec.file>
   </properties>
 
   <repositories>
@@ -2064,48 +2068,14 @@
     <profile>
       <id>sonarcloud-analysis</id>
       <properties>
-        <!--suppress UnresolvedMavenProperty -->
-        <jacoco.master.exec.file>${maven.multiModuleProjectDirectory}/target/jacoco.exec</jacoco.master.exec.file>
-        <sonar.jacoco.reportPaths>${jacoco.master.exec.file}</sonar.jacoco.reportPaths>
+        <sonar.jacoco.reportPaths>${jacoco.exec.file}</sonar.jacoco.reportPaths>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.organization>kiegroup</sonar.organization>
         <!--suppress UnresolvedMavenProperty -->
         <sonar.login>${env.SONARCLOUD_TOKEN}</sonar.login>
       </properties>
       <build>
-        <pluginManagement>
-          <plugins>
-            <plugin>
-              <groupId>org.jacoco</groupId>
-              <artifactId>jacoco-maven-plugin</artifactId>
-              <configuration>
-                <fileSets>
-                  <fileSet>
-                    <directory>${project.build.directory}</directory>
-                    <includes>
-                      <include>*.exec</include>
-                    </includes>
-                  </fileSet>
-                </fileSets>
-                <destFile>${jacoco.master.exec.file}</destFile>
-              </configuration>
-            </plugin>
-          </plugins>
-        </pluginManagement>
         <plugins>
-          <plugin>
-            <groupId>org.jacoco</groupId>
-            <artifactId>jacoco-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <goals>
-                  <goal>report</goal>
-                  <goal>merge</goal>
-                </goals>
-                <phase>generate-resources</phase>
-              </execution>
-            </executions>
-          </plugin>
           <plugin>
             <groupId>org.sonarsource.scanner.maven</groupId>
             <artifactId>sonar-maven-plugin</artifactId>


### PR DESCRIPTION
Using JaCoCo append mode to store coverage data into a single .exec file located in project's root directory/target.