### PR TITLE
BAQE-982: Upgrade version.org.codehaus.cargo to 1.7.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -369,7 +369,7 @@
     <version.org.antlr4>4.7.2</version.org.antlr4>
     <version.org.apache.cxf>3.2.8</version.org.apache.cxf>
     <version.org.apache.camel>2.24.0</version.org.apache.camel>
-    <version.org.codehaus.cargo>1.7.1</version.org.codehaus.cargo>
+    <version.org.codehaus.cargo>1.7.6</version.org.codehaus.cargo>
     <!-- Custom Freemarker build with workaround for random concurrent access issue (annotation processors). See AF-600 for more info.-->
     <version.org.freemarker>2.3.26.jbossorg-1</version.org.freemarker>
     <!-- Dependencies for selenium tests -->


### PR DESCRIPTION
This PR upgrades the cargo version to 1.7.6. It is needed due to the issue https://codehaus-cargo.atlassian.net/browse/CARGO-1488.

It is causing [1] in community selenium tests [2]

[1]
02:43:40,010 ERROR [org.uberfire.ext.security.management.BackendUserSystemManager] (MSC service thread 1-5) UserManagementService destroy failure: java.lang.RuntimeException: Properties file for users not found at './standalone/configuration/application-users.properties'.

[2]
https://github.com/kiegroup/kie-wb-distributions/tree/master/business-central-tests/business-central-tests-gui/src/test/java/org/kie/wb/selenium/ui