### PR TITLE
AF-2150: updating freemarker to 2.3.28

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -370,8 +370,7 @@
     <version.org.apache.cxf>3.2.8</version.org.apache.cxf>
     <version.org.apache.camel>2.24.0</version.org.apache.camel>
     <version.org.codehaus.cargo>1.7.6</version.org.codehaus.cargo>
-    <!-- Custom Freemarker build with workaround for random concurrent access issue (annotation processors). See AF-600 for more info.-->
-    <version.org.freemarker>2.3.26.jbossorg-1</version.org.freemarker>
+    <version.org.freemarker>2.3.28</version.org.freemarker>
     <!-- Dependencies for selenium tests -->
     <version.org.jboss.arquillian.selenium>3.13.0</version.org.jboss.arquillian.selenium>
     <version.org.jboss.arquillian.extension.drone>2.5.1</version.org.jboss.arquillian.extension.drone>


### PR DESCRIPTION
Change-Id: I0a0db79b253ff9c600bc1b98da48f4f38bcb98b9

https://issues.jboss.org/browse/AF-2150