### PR TITLE
upgrade jackson and jackson-databind to 2.9.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,8 @@
     <version.com.datastax.cassandra.cassandra-driver-core>1.0.0
     </version.com.datastax.cassandra.cassandra-driver-core>
     <version.com.drewnoakes.metadata-extractor>2.6.2</version.com.drewnoakes.metadata-extractor>
-    <version.com.fasterxml.jackson>2.9.8</version.com.fasterxml.jackson>
+    <version.com.fasterxml.jackson>2.9.9</version.com.fasterxml.jackson>
+    <version.com.fasterxml.jackson.databind>2.9.9.3</version.com.fasterxml.jackson.databind>
     <version.com.github.gwtbootstrap>2.2.1.0</version.com.github.gwtbootstrap>
     <version.com.google.code.gin>1.0</version.com.google.code.gin>
     <version.com.google.code.gson>2.8.2</version.com.google.code.gson>
@@ -2308,7 +2309,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>${version.com.fasterxml.jackson}</version>
+        <version>${version.com.fasterxml.jackson.databind}</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
Change-Id: I85767d32feee0b03d3e110a7546f81678041f617

Trying to upgrade to the latest upstream which is backward compatible with our code