### PR TITLE
AF-2086: Adding keycloak-common

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4779,6 +4779,11 @@
       </dependency>
       <dependency>
         <groupId>org.keycloak</groupId>
+        <artifactId>keycloak-common</artifactId>
+        <version>${version.org.keycloak}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.keycloak</groupId>
         <artifactId>keycloak-adapter-core</artifactId>
         <version>${version.org.keycloak}</version>
       </dependency>


### PR DESCRIPTION
Adding keycloak common dependency. It is used by -> https://github.com/kiegroup/kie-wb-distributions/pull/955


Depends on https://github.com/kiegroup/kie-wb-distributions/pull/955
