### PR TITLE
BXMSPROD-491 clean duplicated management of dependencies in KIE-PARENT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5399,69 +5399,6 @@
         <version>${version.xpp3}</version>
       </dependency>
 
-
-      <!-- Dependency management should import only the user BOMs. Rest of the 3rp party versions are coming directly
->>>>>>> BXMSPROD-8: refactor to build without jboss-ip-bom
->>>>>>> BXMSPROD-8: refactor to build without jboss-ip-bom
->>>>>>> BXMSPROD-8: refactor to build without jboss-ip-bom
-           from kie-parent.
-           When adding new 3rd dependencies, do it in the kie-parent and not here! -->
-      <dependency>
-        <groupId>org.kie</groupId>
-        <artifactId>kie-bom</artifactId>
-        <type>pom</type>
-        <version>${version.org.kie}</version>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.drools</groupId>
-        <artifactId>drools-bom</artifactId>
-        <type>pom</type>
-        <version>${version.org.kie}</version>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.optaplanner</groupId>
-        <artifactId>optaplanner-bom</artifactId>
-        <type>pom</type>
-        <version>${version.org.kie}</version>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.jbpm</groupId>
-        <artifactId>jbpm-bom</artifactId>
-        <type>pom</type>
-        <version>${version.org.kie}</version>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.kie.uberfire</groupId>
-        <artifactId>kie-uberfire-extensions-bom</artifactId>
-        <type>pom</type>
-        <version>${version.org.kie}</version>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.kie.soup</groupId>
-        <artifactId>kie-soup-bom</artifactId>
-        <type>pom</type>
-        <version>${version.org.kie}</version>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.kie</groupId>
-        <artifactId>kie-dmn-bom</artifactId>
-        <type>pom</type>
-        <version>${version.org.kie}</version>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.uberfire</groupId>
-        <artifactId>uberfire-bom</artifactId>
-        <type>pom</type>
-        <version>${version.org.kie}</version>
-        <scope>import</scope>
-      </dependency>
       <dependency>
         <groupId>org.jboss.errai.bom</groupId>
         <artifactId>errai-internal-bom</artifactId>


### PR DESCRIPTION
Related PRs:
https://github.com/kiegroup/droolsjbpm-knowledge/pull/399
https://github.com/kiegroup/drools/pull/2511
https://github.com/kiegroup/optaplanner/pull/533
https://github.com/kiegroup/jbpm/pull/1529
https://github.com/kiegroup/openshift-drools-hacep/pull/27
https://github.com/kiegroup/droolsjbpm-tools/pull/97
https://github.com/kiegroup/kie-wb-playground/pull/79
https://github.com/kiegroup/jbpm-designer/pull/860