### PR TITLE
BXMSPROD-524: added shell script for removing branches on Gerrit

### DIFF
--- a/script/release/kie-removeReleaseBranchesGerrit.sh
+++ b/script/release/kie-removeReleaseBranchesGerrit.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -e
+
+#!/bin/bash -e
+
+# removes release branches on Gerrit since the tag is already on Gerrit
+if [ "$target" == "productized" ]; then
+  ./droolsjbpm-build-bootstrap/script/git-all.sh push gerrit :$releaseBranch
+fi


### PR DESCRIPTION
adds the new sh script that removes created release branches, only in case the target=productized