### PR TITLE
Upgrade javax.validation from 1.0.0.GA to 2.0.1.Final 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -406,8 +406,7 @@
     <!-- please look at https://github.com/fredsa/gwt-dnd/wiki/GettingStarted -->
     <version.net.ltgt.gwt.maven>1.0-rc-6</version.net.ltgt.gwt.maven>
     <version.org.kie.gwthelper.maven>1.3</version.org.kie.gwthelper.maven>
-    <!-- Version 1.1.0.Final which is coming from ip-bom is not compatible with GWT 2.8.0.Beta1 -->
-    <version.javax.validation>1.0.0.GA</version.javax.validation>
+    <version.javax.validation>2.0.1.Final</version.javax.validation>
     <version.javax.xml.stream.stax>1.0-2</version.javax.xml.stream.stax>
     <version.org.ops4j.pax.url>2.2.0</version.org.ops4j.pax.url>
     <version.org.geronimo.atinject>1.0</version.org.geronimo.atinject>


### PR DESCRIPTION
so its compatible with hibernate-validator (as it is declared in that pom already)

**TODO: if this breaks any of the GWT builds, the GWT repositories should overwrite version.javax.validation in their root pom back to 1.0.0.GA.**