### PR TITLE
Upgrade wildfly-common to 1.5 and xnio to 3.7 and restEasy to 4.2.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -263,8 +263,7 @@
     </version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.2_spec>
     <version.org.jboss.spec.javax.xml.ws.jboss-jaxws-api_2.3_spec>1.0.0.Final
     </version.org.jboss.spec.javax.xml.ws.jboss-jaxws-api_2.3_spec>
-    <version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.3_spec>1.0.1.Final
-    </version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.3_spec>
+    <version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.3_spec>1.0.1.Final</version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.3_spec>
     <version.org.jboss.solder>3.2.1.Final</version.org.jboss.solder>
     <version.org.jboss.staxmapper>1.3.0.Final</version.org.jboss.staxmapper>
     <version.org.jboss.weld.weld>2.4.1.Final</version.org.jboss.weld.weld>
@@ -321,7 +320,7 @@
     <version.org.wildfly>14.0.1.Final</version.org.wildfly>
     <version.org.wildfly.arquillian>2.1.1.Final</version.org.wildfly.arquillian>
     <version.org.wildfly.core>6.0.2.Final</version.org.wildfly.core>
-    <version.org.wildfly.common>1.5.0.Final-format-001</version.org.wildfly.common>
+    <version.org.wildfly.common>1.5.0.Final</version.org.wildfly.common>
     <version.org.yaml.snakeyaml>1.18</version.org.yaml.snakeyaml>
     <version.postgresql>8.4-702.jdbc4</version.postgresql>
     <version.org.mozilla.rhino>1.7R4</version.org.mozilla.rhino>
@@ -381,7 +380,7 @@
     <version.org.jboss.errai>4.6.0.Final</version.org.jboss.errai>
     <version.org.jboss.errai.wildfly>14.0.1.Final</version.org.jboss.errai.wildfly>
     <version.org.jboss.remotingjmx>3.0.0.Final</version.org.jboss.remotingjmx>
-    <version.org.jboss.resteasy.async>3.0.19.Final</version.org.jboss.resteasy.async>
+    <version.org.jboss.resteasy.async>4.2.0.Final</version.org.jboss.resteasy.async>
     <!-- Required by jboss-remoting version above -->
     <version.org.wildfly.security>1.1.0.Final</version.org.wildfly.security>
     <version.org.mortbay.jetty.runner>8.1.7.v20120910</version.org.mortbay.jetty.runner>
@@ -512,8 +511,7 @@
     <version.javax.xml.soap>1.4.0</version.javax.xml.soap>
     <version.javax.jws>1.0-MR1</version.javax.jws>
 
-    <version.org.jboss.spec.javax.ws.rs.jboss-jaxrs-api_2.1_spec>1.0.1.Final
-    </version.org.jboss.spec.javax.ws.rs.jboss-jaxrs-api_2.1_spec>
+    <version.org.jboss.spec.javax.ws.rs.jboss-jaxrs-api_2.1_spec>1.0.2.Final</version.org.jboss.spec.javax.ws.rs.jboss-jaxrs-api_2.1_spec>
     <version.org.apache.maven.plugins.dependency>3.0.2</version.org.apache.maven.plugins.dependency>
 
     <version.org.postgresql>9.4.1207</version.org.postgresql>

--- a/pom.xml
+++ b/pom.xml
@@ -269,7 +269,7 @@
     <version.org.jboss.staxmapper>1.3.0.Final</version.org.jboss.staxmapper>
     <version.org.jboss.weld.weld>2.4.1.Final</version.org.jboss.weld.weld>
     <version.org.jboss.weld.weld-api>3.0.SP4</version.org.jboss.weld.weld-api>
-    <version.org.jboss.xnio>3.6.5.Final</version.org.jboss.xnio>
+    <version.org.jboss.xnio>3.7.2.Final</version.org.jboss.xnio>
     <version.org.jboss.ws.api>1.0.3.Final</version.org.jboss.ws.api>
     <version.org.jboss.ws.spi>3.1.4.Final</version.org.jboss.ws.spi>
     <version.org.jboss.ws.cxf>5.2.4.Final</version.org.jboss.ws.cxf>
@@ -321,7 +321,7 @@
     <version.org.wildfly>14.0.1.Final</version.org.wildfly>
     <version.org.wildfly.arquillian>2.1.1.Final</version.org.wildfly.arquillian>
     <version.org.wildfly.core>6.0.2.Final</version.org.wildfly.core>
-    <version.org.wildfly.common>1.2.0.Final</version.org.wildfly.common>
+    <version.org.wildfly.common>1.5.0.Final-format-001</version.org.wildfly.common>
     <version.org.yaml.snakeyaml>1.18</version.org.yaml.snakeyaml>
     <version.postgresql>8.4-702.jdbc4</version.postgresql>
     <version.org.mozilla.rhino>1.7R4</version.org.mozilla.rhino>


### PR DESCRIPTION
Fixes this mess:
https://stackoverflow.com/questions/58014229/mvn-quarkusdev-throws-noclassdeffounderror-could-not-initialize-class-org-j