### PR TITLE
fixed right remote name

### DIFF
--- a/script/release/kie-removeReleaseBranchesGerrit.sh
+++ b/script/release/kie-removeReleaseBranchesGerrit.sh
@@ -1,8 +1,6 @@
 #!/bin/bash -e
 
-#!/bin/bash -e
-
 # removes release branches on Gerrit since the tag is already on Gerrit
 if [ "$target" == "productized" ]; then
-  ./droolsjbpm-build-bootstrap/script/git-all.sh push gerrit :$releaseBranch
+  ./droolsjbpm-build-bootstrap/script/git-all.sh push origin :$releaseBranch
 fi


### PR DESCRIPTION
If productized is selected in release-jobs the remote name pointing to Gerrit is *origin*.
The remote Gerrit in these cases is pointing to nowhere since it doesn't exist.