### PR TITLE
BAQE-1114 - Change revapi to check against 7.26.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -503,7 +503,7 @@
 
 
     <!-- Latest release to be used by api-compatibility-check to check backwards compatibility of the Kie API. -->
-    <revapi.oldKieVersion>7.23.0.Final</revapi.oldKieVersion>
+    <revapi.oldKieVersion>7.26.0.Final</revapi.oldKieVersion>
     <revapi.newKieVersion>${project.version}</revapi.newKieVersion>
 
     <version.org.jboss.spec.javax.websocket>1.1.3.Final</version.org.jboss.spec.javax.websocket>


### PR DESCRIPTION
Wait with merge until all valid repositories are good to go.

@rsynek

We now have to check against latest product release (7.5 DM/PAM) which means that we have to check against 7.26.0.Final community release.