### PR TITLE
Bump version.org.jfree.jfreechart from 1.0.19 to 1.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -273,8 +273,7 @@
     <version.org.jboss.ws.spi>3.1.4.Final</version.org.jboss.ws.spi>
     <version.org.jboss.ws.cxf>5.2.4.Final</version.org.jboss.ws.cxf>
     <version.org.jdom>1.1.3</version.org.jdom>
-    <version.org.jfree.jcommon>1.0.23</version.org.jfree.jcommon>
-    <version.org.jfree.jfreechart>1.0.19</version.org.jfree.jfreechart>
+    <version.org.jfree.jfreechart>1.5.0</version.org.jfree.jfreechart>
     <version.org.jgroups>4.0.15.Final</version.org.jgroups>
     <version.org.jpmml.model>1.4.11
     </version.org.jpmml.model> <!-- jpmml-model BSD 3C license - ATTENTION 1.4.11 intentional, because 1.4.9 evaluators depend on 1.4.11 -->
@@ -4204,12 +4203,8 @@
           </exclusion>
           <exclusion>
             <artifactId>jfreechart</artifactId>
-            <groupId>jfree</groupId>
-          </exclusion>
-          <exclusion>
-            <artifactId>jcommon</artifactId>
-            <groupId>jfree</groupId>
-          </exclusion>
+            <groupId>org.jfree</groupId>
+          </exclusion>          
           <exclusion>
             <artifactId>jboss-corba-ots-spi</artifactId>
             <groupId>org.jboss.integration</groupId>
@@ -4248,10 +4243,6 @@
           </exclusion>
           <exclusion>
             <artifactId>jfreechart</artifactId>
-            <groupId>org.jfree</groupId>
-          </exclusion>
-          <exclusion>
-            <artifactId>jcommon</artifactId>
             <groupId>org.jfree</groupId>
           </exclusion>
           <exclusion>
@@ -4300,11 +4291,7 @@
           </exclusion>
           <exclusion>
             <artifactId>jfreechart</artifactId>
-            <groupId>jfree</groupId>
-          </exclusion>
-          <exclusion>
-            <artifactId>jcommon</artifactId>
-            <groupId>jfree</groupId>
+            <groupId>org.jfree</groupId>
           </exclusion>
           <exclusion>
             <artifactId>jboss-corba-ots-spi</artifactId>
@@ -4344,10 +4331,6 @@
           </exclusion>
           <exclusion>
             <artifactId>jfreechart</artifactId>
-            <groupId>org.jfree</groupId>
-          </exclusion>
-          <exclusion>
-            <artifactId>jcommon</artifactId>
             <groupId>org.jfree</groupId>
           </exclusion>
           <exclusion>
@@ -4713,11 +4696,6 @@
         <version>${version.org.jdom}</version>
       </dependency>
 
-      <dependency>
-        <groupId>org.jfree</groupId>
-        <artifactId>jcommon</artifactId>
-        <version>${version.org.jfree.jcommon}</version>
-      </dependency>
       <dependency>
         <groupId>org.jfree</groupId>
         <artifactId>jfreechart</artifactId>


### PR DESCRIPTION
This pull request is an upgrade of JFreeChart library.
This also allows to remove jcommon dependency.

Requires these changes on optaplanner repo: https://github.com/kiegroup/optaplanner/pull/576