### PR TITLE
Upgrade Jackson version to 2.10.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
     <version.com.ahome-it.lienzo.tooling.common>1.0.190-RELEASE</version.com.ahome-it.lienzo.tooling.common>
     <version.com.allen-sauer.gwt.dnd>3.3.3</version.com.allen-sauer.gwt.dnd>
     <version.com.fasterxml.jackson>2.10.1</version.com.fasterxml.jackson>
-    <version.com.fasterxml.jackson.databind>2.9.10.1</version.com.fasterxml.jackson.databind>
+    <version.com.fasterxml.jackson.databind>2.10.1</version.com.fasterxml.jackson.databind>
     <version.com.google.code.gson>2.8.2</version.com.google.code.gson>
     <version.com.google.guava>25.0-jre</version.com.google.guava>
     <version.com.google.inject.guice>4.0</version.com.google.inject.guice>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
     </version.com.ahome-it.lienzo.tooling.nativetools>
     <version.com.ahome-it.lienzo.tooling.common>1.0.190-RELEASE</version.com.ahome-it.lienzo.tooling.common>
     <version.com.allen-sauer.gwt.dnd>3.3.3</version.com.allen-sauer.gwt.dnd>
-    <version.com.fasterxml.jackson>2.9.9</version.com.fasterxml.jackson>
+    <version.com.fasterxml.jackson>2.10.1</version.com.fasterxml.jackson>
     <version.com.fasterxml.jackson.databind>2.9.10.1</version.com.fasterxml.jackson.databind>
     <version.com.google.code.gson>2.8.2</version.com.google.code.gson>
     <version.com.google.guava>25.0-jre</version.com.google.guava>

--- a/pom.xml
+++ b/pom.xml
@@ -2257,6 +2257,16 @@
         <groupId>com.fasterxml.jackson.module</groupId>
         <artifactId>jackson-module-jaxb-annotations</artifactId>
         <version>${version.com.fasterxml.jackson}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.dataformat</groupId>
@@ -2267,6 +2277,16 @@
         <groupId>com.fasterxml.jackson.jaxrs</groupId>
         <artifactId>jackson-jaxrs-json-provider</artifactId>
         <version>${version.com.fasterxml.jackson}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.jaxrs</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -259,7 +259,7 @@
     <version.org.wildfly.arquillian>2.1.1.Final</version.org.wildfly.arquillian>
     <version.org.wildfly.core>6.0.2.Final</version.org.wildfly.core>
     <version.org.wildfly.common>1.5.0.Final</version.org.wildfly.common>
-    <version.org.yaml.snakeyaml>1.18</version.org.yaml.snakeyaml>
+    <version.org.yaml.snakeyaml>1.25</version.org.yaml.snakeyaml>
     <version.postgresql>8.4-702.jdbc4</version.postgresql>
     <version.org.mozilla.rhino>1.7R4</version.org.mozilla.rhino>
     <version.rome>1.0</version.rome>


### PR DESCRIPTION
Jira: https://issues.jboss.org/browse/PLANNER-1695

Is a prerequisite for: https://github.com/kiegroup/optaweb-vehicle-routing/pull/221

Depends on: https://github.com/kiegroup/droolsjbpm-integration/pull/1948