### PR TITLE
AF-2333: Apache mina-core library depMgmt removed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,6 @@
     <version.org.apache.maven.plugin-testing>2.1</version.org.apache.maven.plugin-testing>
     <version.org.apache.maven.plugin-tools>3.4</version.org.apache.maven.plugin-tools>
     <version.org.apache.maven.wagon>3.0.0</version.org.apache.maven.wagon>
-    <version.org.apache.mina>2.0.15</version.org.apache.mina>
     <version.org.apache.neethi>3.1.1</version.org.apache.neethi>
     <version.org.apache.poi>3.17</version.org.apache.poi>
     <version.org.apache.sshd>1.6.0</version.org.apache.sshd>
@@ -3446,12 +3445,6 @@
         <groupId>org.apache.neethi</groupId>
         <artifactId>neethi</artifactId>
         <version>${version.org.apache.neethi}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.apache.mina</groupId>
-        <artifactId>mina-core</artifactId>
-        <version>${version.org.apache.mina}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Change-Id: I4f875d4b88ec51b1aa78d3b62c6753e4878e9006

https://issues.jboss.org/browse/AF-2333

Downstream PR kiegroup/kie-wb-common/pull/3020