### PR TITLE
RHDM-874: CVE-2018-20676 bootstrap: XSS in the tooltip data-viewport attribute [rhdm-7.2.1]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -202,7 +202,8 @@
     <version.org.eclipse.sisu>0.3.2</version.org.eclipse.sisu>
     <version.org.eclipse.emf.gwt>2.9.0</version.org.eclipse.emf.gwt>
     <version.org.glassfish>3.1.2</version.org.glassfish>
-    <version.org.gwtbootstrap3>0.9.3</version.org.gwtbootstrap3>
+    <version.org.gwtbootstrap3>1.0.1</version.org.gwtbootstrap3>
+    <version.org.gwtbootstrap3-extras>1.0.2</version.org.gwtbootstrap3-extras>
     <version.org.hibernate>5.3.7.Final</version.org.hibernate>
     <version.org.hibernate.search>5.10.3.Final</version.org.hibernate.search>
     <version.org.hibernate.validator>6.0.13.Final</version.org.hibernate.validator>
@@ -3927,7 +3928,7 @@
       <dependency>
         <groupId>org.gwtbootstrap3</groupId>
         <artifactId>gwtbootstrap3-extras</artifactId>
-        <version>${version.org.gwtbootstrap3}</version>
+        <version>${version.org.gwtbootstrap3-extras}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
- Upgraded bootstrap to v3.4.1 (PR : https://github.com/gwtbootstrap3/gwtbootstrap3/pull/526).
- This upgrade fixes the XSS vulnerability on tooltips,popover etc present in business central. (see release notes - https://github.com/twbs/bootstrap/releases/tag/v3.4.1).
- When a malicious script is inserted, The user page will fail to load and they can see error as shown in screenshot.
![xss-bootstrap](https://user-images.githubusercontent.com/23648802/69051981-d9131780-0a2b-11ea-9626-09440cc41fe7.png)
