### PR TITLE
PLANNER-1192 Replace junit with junit-vintage-engine

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6222,6 +6222,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
This PR serves as a PoC of running tests in Junit5 through the junit-vintage-engine.