### PR TITLE
PLANNER-1682: Remove optaplanner-core-gwt module

### DIFF
--- a/optaplanner-bom/pom.xml
+++ b/optaplanner-bom/pom.xml
@@ -206,12 +206,6 @@
       </dependency>
       <dependency>
         <groupId>org.optaplanner</groupId>
-        <artifactId>optaplanner-core-gwt</artifactId>
-        <version>${version.org.kie}</version>
-        <type>gwt-lib</type>
-      </dependency>
-      <dependency>
-        <groupId>org.optaplanner</groupId>
         <artifactId>optaplanner-benchmark</artifactId>
         <version>${version.org.kie}</version>
       </dependency>


### PR DESCRIPTION
Part of PR set:
https://github.com/kiegroup/optaplanner/pull/619