### PR TITLE
Remove optaplanner-spring-boot-example artifactId

### DIFF
--- a/optaplanner-bom/pom.xml
+++ b/optaplanner-bom/pom.xml
@@ -303,23 +303,6 @@
       </dependency>
       <dependency>
         <groupId>org.optaplanner</groupId>
-        <artifactId>optaplanner-spring-boot-example</artifactId>
-        <version>${version.org.kie}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.optaplanner</groupId>
-        <artifactId>optaplanner-spring-boot-example</artifactId>
-        <version>${version.org.kie}</version>
-        <classifier>sources</classifier>
-      </dependency>
-      <dependency>
-        <groupId>org.optaplanner</groupId>
-        <artifactId>optaplanner-spring-boot-example</artifactId>
-        <type>test-jar</type>
-        <version>${version.org.kie}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.optaplanner</groupId>
         <artifactId>optaplanner-docs</artifactId>
         <type>zip</type>
         <version>${version.org.kie}</version>


### PR DESCRIPTION
Following Spring Boot (and Quarkus) conventions it becoming a quickstart instead and it's going into a versionless, non-released repository (hopefully as a spring guide).
We'll likely add other examples on kogito-examples.