### PR TITLE
[PLANNER-1753] Bump and add Spring Boot dependency management for optaplanner-integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -306,8 +306,8 @@
     <version.org.sonatype.plexus.plexus-sec-dispatcher>1.3</version.org.sonatype.plexus.plexus-sec-dispatcher>
     <version.org.sonatype.sisu>2.3.0</version.org.sonatype.sisu>
     <version.org.sonatype.sisu.sisu-guice>3.2.3</version.org.sonatype.sisu.sisu-guice>
-    <version.org.springframework>5.2.1.RELEASE</version.org.springframework>
-    <version.org.springframework.boot>2.2.1.RELEASE</version.org.springframework.boot>
+    <version.org.springframework>5.2.2.RELEASE</version.org.springframework>
+    <version.org.springframework.boot>2.2.2.RELEASE</version.org.springframework.boot>
     <version.org.springframework.osgi>1.2.1</version.org.springframework.osgi>
     <version.org.subethamail>1.2</version.org.subethamail>
     <version.org.subethamail.subethasmtp>3.1.6</version.org.subethamail.subethasmtp>
@@ -5149,6 +5149,32 @@
         <groupId>org.springframework</groupId>
         <artifactId>spring-websocket</artifactId>
         <version>${version.org.springframework}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-autoconfigure</artifactId>
+        <version>${version.org.springframework.boot}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-configuration-processor</artifactId>
+        <version>${version.org.springframework.boot}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-autoconfigure-processor</artifactId>
+        <version>${version.org.springframework.boot}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-test</artifactId>
+        <version>${version.org.springframework.boot}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-test-autoconfigure</artifactId>
+        <version>${version.org.springframework.boot}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/PLANNER-1753

Prerequisite for: https://github.com/kiegroup/optaplanner/pull/640