### PR TITLE
BXMSPROD-598 thorntail-maven-plugin upgraded to 2.7.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -412,7 +412,7 @@
     <!-- Version of the KIE Workbench application. Shown for example in About dialog. Will be usually overridden by productisation. -->
     <version.org.kie.workbench.app>${version.org.kie}</version.org.kie.workbench.app>
 
-    <version.thorntail>2.5.0.Final</version.thorntail>
+    <version.thorntail>2.6.0.Final</version.thorntail>
     <version.net.byte-buddy>1.10.3</version.net.byte-buddy>
     <version.docker-client>3.5.12</version.docker-client>
     <version.kubernetes-client>4.6.0</version.kubernetes-client>

--- a/pom.xml
+++ b/pom.xml
@@ -412,7 +412,7 @@
     <!-- Version of the KIE Workbench application. Shown for example in About dialog. Will be usually overridden by productisation. -->
     <version.org.kie.workbench.app>${version.org.kie}</version.org.kie.workbench.app>
 
-    <version.thorntail>2.6.0.Final</version.thorntail>
+    <version.thorntail>2.7.0.Final</version.thorntail>
     <version.net.byte-buddy>1.10.3</version.net.byte-buddy>
     <version.docker-client>3.5.12</version.docker-client>
     <version.kubernetes-client>4.6.0</version.kubernetes-client>


### PR DESCRIPTION
BXMSPROD-598
Depends on https://github.com/thorntail/thorntail/pull/1362 and 2.6.0 release