### PR TITLE
KOGITO-879 KOGITO-880 KOGITO-881: State Control API (undo/redo)

### DIFF
--- a/kie-bom/pom.xml
+++ b/kie-bom/pom.xml
@@ -2439,6 +2439,19 @@
         <type>test-jar</type>
       </dependency>
 
+      <dependency>
+        <groupId>org.kie.workbench.stunner</groupId>
+        <artifactId>kie-wb-common-stunner-kogito-runtime-common</artifactId>
+        <version>${version.org.kie}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.kie.workbench.stunner</groupId>
+        <artifactId>kie-wb-common-stunner-kogito-runtime-common</artifactId>
+        <version>${version.org.kie}</version>
+        <classifier>sources</classifier>
+      </dependency>
+
       <!-- Stunner - BPMN-->
 
       <dependency>

--- a/uberfire-bom/pom.xml
+++ b/uberfire-bom/pom.xml
@@ -1487,7 +1487,18 @@
         <classifier>sources</classifier>
       </dependency>
 
-      <!--Appformer Kogito Bridge-->
+      <!--Appformer Kogito-->
+      <dependency>
+        <groupId>org.uberfire</groupId>
+        <artifactId>appformer-kogito-api</artifactId>
+        <version>${version.org.uberfire}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.uberfire</groupId>
+        <artifactId>appformer-kogito-api</artifactId>
+        <version>${version.org.uberfire}</version>
+        <classifier>sources</classifier>
+      </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>appformer-kogito-bridge</artifactId>

--- a/uberfire-bom/pom.xml
+++ b/uberfire-bom/pom.xml
@@ -1487,18 +1487,7 @@
         <classifier>sources</classifier>
       </dependency>
 
-      <!--Appformer Kogito-->
-      <dependency>
-        <groupId>org.uberfire</groupId>
-        <artifactId>appformer-kogito-api</artifactId>
-        <version>${version.org.uberfire}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.uberfire</groupId>
-        <artifactId>appformer-kogito-api</artifactId>
-        <version>${version.org.uberfire}</version>
-        <classifier>sources</classifier>
-      </dependency>
+      <!-- Appformer Kogito-->
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>appformer-kogito-bridge</artifactId>
@@ -1840,6 +1829,21 @@
         <type>war</type>
       </dependency>
 
+
+      <!-- Appformer -->
+      <dependency>
+        <groupId>org.uberfire</groupId>
+        <artifactId>appformer-client-api</artifactId>
+        <version>${version.org.uberfire}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.uberfire</groupId>
+        <artifactId>appformer-client-api</artifactId>
+        <version>${version.org.uberfire}</version>
+        <classifier>sources</classifier>
+      </dependency>
+
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>appformer-js-bridge</artifactId>
@@ -1858,6 +1862,8 @@
         <artifactId>appformer-js</artifactId>
         <version>${version.org.uberfire}</version>
       </dependency>
+
+
 
     </dependencies>
 


### PR DESCRIPTION
KOGITO-879: Define State Control API
KOGITO-880: Create JSInterop layer for StateControl API
KOGITO-881: Integrate State Control API in Stunner to handle Undo & Redo

I had to add two new modules:
- `appformer-kogito-api`: to keep the base kogito APIs (for now only StateControl APIs are there), since this module may grow and the state control is a development linked to the envelope, I thoght it was a good idea to have it there.

- `kie-wb-common-stunner-kogito-runtime-common`: to keep the shared classes nedded for the stunner editor runtimes. Other modules under kie-wb-common-stunner-kogito are also present on BC.

@ederign @tiagobento @jomarko would you mind take a look?

This is part of an ensemble, please merge with:
https://github.com/kiegroup/kogito-tooling/pull/66
https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1195
https://github.com/kiegroup/appformer/pull/894
https://github.com/kiegroup/kie-wb-common/pull/3156
https://github.com/kiegroup/jbpm-wb/pull/1414
https://github.com/kiegroup/drools-wb/pull/1310
https://github.com/kiegroup/kie-wb-distributions/pull/1013

