### PR TITLE
DROOLS-5057: Unify xsd -> java -> js conversion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,7 @@
     <version.com.google.gwt>2.8.2</version.com.google.gwt>
     <version.org.google.gwt-charts>0.9.9</version.org.google.gwt-charts>
     <version.com.google.gwt.gwtmockito>1.1.8</version.com.google.gwt.gwtmockito>
+    <version.com.google.jsinterop.base>1.0.0-beta-1</version.com.google.jsinterop.base>
     <version.com.google.jsinterop>1.0.1</version.com.google.jsinterop>
     <version.com.google.protobuf>3.6.1</version.com.google.protobuf>
     <version.com.h2database>1.3.173</version.com.h2database>
@@ -466,6 +467,10 @@
 
     <version.org.awaitility>3.0.0</version.org.awaitility>
     <version.io.github.bonigarcia>3.8.1</version.io.github.bonigarcia>
+
+    <version.org.kogito.gwt-jsonix-schema-compiler>1.1.0</version.org.kogito.gwt-jsonix-schema-compiler>
+    <version.org.hisrc.jsonix.jsonix-scripts>3.0.0</version.org.hisrc.jsonix.jsonix-scripts>
+    <version.org.jvnet.jaxb2.maven2.maven-jaxb2-plugin>0.14.0</version.org.jvnet.jaxb2.maven2.maven-jaxb2-plugin>
   </properties>
 
   <repositories>
@@ -5092,6 +5097,18 @@
         <artifactId>webdrivermanager</artifactId>
         <version>${version.io.github.bonigarcia}</version>
         <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.kogito</groupId>
+        <artifactId>gwt-jsonix-schema-compiler</artifactId>
+        <version>${version.org.kogito.gwt-jsonix-schema-compiler}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.google.jsinterop</groupId>
+        <artifactId>base</artifactId>
+        <version>${version.com.google.jsinterop.base}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
We use set of librares for xsd -> java -> js conversion.
Such conversion is is needed in DMN and Scenario Simalation marshaling modules to be able run editors without application server.
This PR unify the versions of used libraries.

For more details see https://issues.redhat.com/browse/DROOLS-5057

Ensemble together with:
- https://github.com/kiegroup/kie-wb-common/pull/3209
- https://github.com/kiegroup/drools-wb/pull/1324