### PR TITLE
KOGITO-1441: [DMN Designer] JsonixGWTPlugin: JSUtils.toAttributesMap(…) null check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -473,7 +473,7 @@
     <version.org.awaitility>3.0.0</version.org.awaitility>
     <version.io.github.bonigarcia>3.8.1</version.io.github.bonigarcia>
 
-    <version.org.kogito.gwt-jsonix-schema-compiler>1.1.0</version.org.kogito.gwt-jsonix-schema-compiler>
+    <version.org.kogito.gwt-jsonix-schema-compiler>1.2.0</version.org.kogito.gwt-jsonix-schema-compiler>
     <version.org.hisrc.jsonix.jsonix-scripts>3.0.0</version.org.hisrc.jsonix.jsonix-scripts>
     <version.org.jvnet.jaxb2.maven2.maven-jaxb2-plugin>0.14.0</version.org.jvnet.jaxb2.maven2.maven-jaxb2-plugin>
   </properties>


### PR DESCRIPTION
See https://issues.redhat.com/browse/KOGITO-1441

@mbiarnes We'll need a new release of the Jsonix plugin to remove this `-SNAPSHOT` dependency for the next `kiegroup` release. Please see the linked PR.

Part of an ensemble:
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1229
- https://github.com/kiegroup/gwt-jsonix-schema-compiler/pull/6