### PR TITLE
BXMSPROD-685: upgrade of different version of org.jboss.spec

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -201,21 +201,21 @@
     <version.org.jboss.shrinkwrap.resolver>2.2.0</version.org.jboss.shrinkwrap.resolver>
     <version.org.jboss.spec.javax.annotation.jboss-annotations-api_1.2_spec>1.0.0.Final
     </version.org.jboss.spec.javax.annotation.jboss-annotations-api_1.2_spec>
-    <version.org.jboss.spec.javax.ejb.jboss-ejb-api_3.2_spec>1.0.1.Final
+    <version.org.jboss.spec.javax.ejb.jboss-ejb-api_3.2_spec>2.0.0.Final
     </version.org.jboss.spec.javax.ejb.jboss-ejb-api_3.2_spec>
-    <version.org.jboss.spec.javax.el.jboss-el-api_3.0_spec>1.0.12.Final
+    <version.org.jboss.spec.javax.el.jboss-el-api_3.0_spec>2.0.0.Final
     </version.org.jboss.spec.javax.el.jboss-el-api_3.0_spec>
-    <version.org.jboss.spec.javax.enterprise.concurrent>1.0.2.Final
+    <version.org.jboss.spec.javax.enterprise.concurrent>2.0.0.Final
     </version.org.jboss.spec.javax.enterprise.concurrent>
-    <version.org.jboss.spec.javax.interceptor.jboss-interceptors-api_1.2_spec>1.0.1.Final
+    <version.org.jboss.spec.javax.interceptor.jboss-interceptors-api_1.2_spec>2.0.0.Final
     </version.org.jboss.spec.javax.interceptor.jboss-interceptors-api_1.2_spec>
-    <version.org.jboss.spec.javax.jms.jboss-jms-api_2.0_spec>1.0.2.Final
+    <version.org.jboss.spec.javax.jms.jboss-jms-api_2.0_spec>2.0.0.Final
     </version.org.jboss.spec.javax.jms.jboss-jms-api_2.0_spec>
-    <version.org.jboss.spec.javax.security.jacc.jboss-jacc-api_1.5_spec>1.0.2.Final
+    <version.org.jboss.spec.javax.security.jacc.jboss-jacc-api_1.5_spec>2.0.0.Final
     </version.org.jboss.spec.javax.security.jacc.jboss-jacc-api_1.5_spec>
     <version.org.jboss.spec.javax.servlet.jboss-servlet-api_3.1_spec>1.0.2.Final
     </version.org.jboss.spec.javax.servlet.jboss-servlet-api_3.1_spec>
-    <version.org.jboss.spec.javax.servlet.jsp.jboss-jsp-api_2.3_spec>1.0.3.Final
+    <version.org.jboss.spec.javax.servlet.jsp.jboss-jsp-api_2.3_spec>2.0.0.Final
     </version.org.jboss.spec.javax.servlet.jsp.jboss-jsp-api_2.3_spec>
     <version.org.jboss.spec.javax.servlet.jstl.jboss-jstl-api_1.2_spec>1.1.3.Final
     </version.org.jboss.spec.javax.servlet.jstl.jboss-jstl-api_1.2_spec>
@@ -432,12 +432,12 @@
     <revapi.oldKieVersion>7.33.0.Final</revapi.oldKieVersion>
     <revapi.newKieVersion>${project.version}</revapi.newKieVersion>
 
-    <version.org.jboss.spec.javax.websocket>1.1.3.Final</version.org.jboss.spec.javax.websocket>
+    <version.org.jboss.spec.javax.websocket>2.0.0.Final</version.org.jboss.spec.javax.websocket>
 
     <version.javax.xml.soap>1.4.0</version.javax.xml.soap>
     <version.javax.jws>1.0-MR1</version.javax.jws>
 
-    <version.org.jboss.spec.javax.ws.rs.jboss-jaxrs-api_2.1_spec>1.0.2.Final</version.org.jboss.spec.javax.ws.rs.jboss-jaxrs-api_2.1_spec>
+    <version.org.jboss.spec.javax.ws.rs.jboss-jaxrs-api_2.1_spec>2.0.1.Final</version.org.jboss.spec.javax.ws.rs.jboss-jaxrs-api_2.1_spec>
     <version.org.apache.maven.plugins.dependency>3.0.2</version.org.apache.maven.plugins.dependency>
 
     <version.org.postgresql>9.4.1207</version.org.postgresql>


### PR DESCRIPTION
upgraded version.org.jboss.spec.javax.ejb.jboss-ejb-api_3.2_spec

upgraded version.org.jboss.spec.javax.el.jboss-el-api_3.0_spec

upgraded version.org.jboss.spec.javax.enterprise.concurrent

upgraded version version.org.jboss.spec.javax.interceptor.jboss-interceptors-api_1.2_spec

upgraded version.org.jboss.spec.javax.jms

upgraded version.org.jboss.spec.javax.security.jacc.jboss-jacc-api_1.5_spec

upgraded version.org.jboss.spec.javax.servlet.jsp

upgraded version.org.jboss.spec.javax.websocket

upgraded version.org.jboss.spec.javax.ws.rs.jboss-jaxrs-api_2.1_spec