### PR TITLE
[JBPM-9069] - com.google.inject:guice artifact needs to be upgraded to version 4.2.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
     <version.com.fasterxml.jackson.databind>2.9.10.3</version.com.fasterxml.jackson.databind>
     <version.com.google.code.gson>2.8.2</version.com.google.code.gson>
     <version.com.google.guava>25.0-jre</version.com.google.guava>
-    <version.com.google.inject.guice>4.0</version.com.google.inject.guice>
+    <version.com.google.inject.guice>4.2.3</version.com.google.inject.guice>
     <version.com.google.gwt>2.8.2</version.com.google.gwt>
     <version.org.google.gwt-charts>0.9.9</version.org.google.gwt-charts>
     <version.com.google.gwt.gwtmockito>1.1.8</version.com.google.gwt.gwtmockito>


### PR DESCRIPTION
[[JBPM-9069]](https://issues.redhat.com/browse/JBPM-9069) - com.google.inject:guice artifact needs to be upgraded to version 4.2.3