### PR TITLE
PLANNER-1003: Remove unneeded JUnit dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2595,11 +2595,6 @@
       </dependency>
       <dependency>
         <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-migrationsupport</artifactId>
-        <version>${version.org.junit}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter-params</artifactId>
         <version>${version.org.junit}</version>
       </dependency>


### PR DESCRIPTION
Fixup for #1288.

The dependency was used at some point when working on kiegroup/optaplanner#764 but is not needed in the ended.