### PR TITLE
BXMSPROD-757 firefox driver path

### DIFF
--- a/downstream.production.stages
+++ b/downstream.production.stages
@@ -14,6 +14,6 @@ stage('Downstream Production Build') {
 
         println "File ${REPOSITORY_LIST_FILE} and ${PRODUCTION_PROJECT_LIST} jenkins file merged in ${projectCollection}"
 
-        treebuild.downstreamBuild(projectCollection, "${SETTINGS_XML_ID}", 'clean install -Dproductized=true -Dmaven.test.failure.ignore=true')
+        treebuild.downstreamBuild(projectCollection, "${SETTINGS_XML_ID}", 'clean install -Dproductized=true -Dmaven.test.failure.ignore=true -Dwebdriver.firefox.bin=/opt/tools/firefox-60esr/firefox-bin')
     }
 }

--- a/downstream.stages
+++ b/downstream.stages
@@ -5,6 +5,6 @@ stage('Downstream Build') {
         println "Reading file ${REPOSITORY_LIST_FILE}"
         def file = readFile REPOSITORY_LIST_FILE
         def projectCollection = file.readLines()
-        treebuild.downstreamBuild(projectCollection, "${SETTINGS_XML_ID}", '-e -nsu -Pbusiness-central,wildfly,sourcemaps,no-showcase clean install -Dfull=true -Dcontainer=wildfly -Dcontainer.profile=wildfly -Dintegration-tests=true -Dmaven.test.failure.ignore=true -Dmaven.test.redirectTestOutputToFile=true -Dgwt.compiler.localWorkers=1')
+        treebuild.downstreamBuild(projectCollection, "${SETTINGS_XML_ID}", '-e -nsu -Pbusiness-central,wildfly,sourcemaps,no-showcase clean install -Dfull=true -Dcontainer=wildfly -Dcontainer.profile=wildfly -Dintegration-tests=true -Dmaven.test.failure.ignore=true -Dmaven.test.redirectTestOutputToFile=true -Dgwt.compiler.localWorkers=1 -Dwebdriver.firefox.bin=/opt/tools/firefox-60esr/firefox-bin')
     }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/BXMSPROD-757
It's not needed for upstream build since the tests are skipped
Tested here https://rhba-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/PROD/job/upstream-downstream/job/drools.downstream/4