### PR TITLE
Revert "BXMSPROD-685: upgrade of org.jboss-weld (#1234)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -223,7 +223,7 @@
     </version.org.jboss.spec.javax.xml.ws.jboss-jaxws-api_2.3_spec>
     <version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.3_spec>1.0.1.Final</version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.3_spec>
     <version.org.jboss.weld.weld>2.4.1.Final</version.org.jboss.weld.weld>
-    <version.org.jboss.weld.weld-api>3.1.SP1</version.org.jboss.weld.weld-api>
+    <version.org.jboss.weld.weld-api>3.0.SP4</version.org.jboss.weld.weld-api>
     <version.org.jboss.xnio>3.7.7.Final</version.org.jboss.xnio>
     <version.org.jdom>1.1.3</version.org.jdom>
     <version.org.jfree.jfreechart>1.5.0</version.org.jfree.jfreechart>


### PR DESCRIPTION
This reverts https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1234 which broke `drools-wb` build.

@kiegroup/gatekeepers could you take a look and, possibly, merge?