### PR TITLE
BXMSPROD-685: second attempt to upgrade of org.jboss.spec deps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -201,21 +201,21 @@
     <version.org.jboss.shrinkwrap.resolver>2.2.0</version.org.jboss.shrinkwrap.resolver>
     <version.org.jboss.spec.javax.annotation.jboss-annotations-api_1.2_spec>1.0.0.Final
     </version.org.jboss.spec.javax.annotation.jboss-annotations-api_1.2_spec>
-    <version.org.jboss.spec.javax.ejb.jboss-ejb-api_3.2_spec>1.0.1.Final
+    <version.org.jboss.spec.javax.ejb.jboss-ejb-api_3.2_spec>2.0.0.Final
     </version.org.jboss.spec.javax.ejb.jboss-ejb-api_3.2_spec>
-    <version.org.jboss.spec.javax.el.jboss-el-api_3.0_spec>1.0.12.Final
+    <version.org.jboss.spec.javax.el.jboss-el-api_3.0_spec>2.0.0.Final
     </version.org.jboss.spec.javax.el.jboss-el-api_3.0_spec>
-    <version.org.jboss.spec.javax.enterprise.concurrent>1.0.2.Final
+    <version.org.jboss.spec.javax.enterprise.concurrent>2.0.0.Final
     </version.org.jboss.spec.javax.enterprise.concurrent>
-    <version.org.jboss.spec.javax.interceptor.jboss-interceptors-api_1.2_spec>1.0.1.Final
+    <version.org.jboss.spec.javax.interceptor.jboss-interceptors-api_1.2_spec>2.0.0.Final
     </version.org.jboss.spec.javax.interceptor.jboss-interceptors-api_1.2_spec>
-    <version.org.jboss.spec.javax.jms.jboss-jms-api_2.0_spec>1.0.2.Final
+    <version.org.jboss.spec.javax.jms.jboss-jms-api_2.0_spec>2.0.0.Final
     </version.org.jboss.spec.javax.jms.jboss-jms-api_2.0_spec>
-    <version.org.jboss.spec.javax.security.jacc.jboss-jacc-api_1.5_spec>1.0.2.Final
+    <version.org.jboss.spec.javax.security.jacc.jboss-jacc-api_1.5_spec>2.0.0.Final
     </version.org.jboss.spec.javax.security.jacc.jboss-jacc-api_1.5_spec>
     <version.org.jboss.spec.javax.servlet.jboss-servlet-api_3.1_spec>1.0.2.Final
     </version.org.jboss.spec.javax.servlet.jboss-servlet-api_3.1_spec>
-    <version.org.jboss.spec.javax.servlet.jsp.jboss-jsp-api_2.3_spec>1.0.3.Final
+    <version.org.jboss.spec.javax.servlet.jsp.jboss-jsp-api_2.3_spec>2.0.0.Final
     </version.org.jboss.spec.javax.servlet.jsp.jboss-jsp-api_2.3_spec>
     <version.org.jboss.spec.javax.servlet.jstl.jboss-jstl-api_1.2_spec>1.1.3.Final
     </version.org.jboss.spec.javax.servlet.jstl.jboss-jstl-api_1.2_spec>
@@ -432,12 +432,12 @@
     <revapi.oldKieVersion>7.33.0.Final</revapi.oldKieVersion>
     <revapi.newKieVersion>${project.version}</revapi.newKieVersion>
 
-    <version.org.jboss.spec.javax.websocket>1.1.3.Final</version.org.jboss.spec.javax.websocket>
+    <version.org.jboss.spec.javax.websocket>2.0.0.Final</version.org.jboss.spec.javax.websocket>
 
     <version.javax.xml.soap>1.4.0</version.javax.xml.soap>
     <version.javax.jws>1.0-MR1</version.javax.jws>
 
-    <version.org.jboss.spec.javax.ws.rs.jboss-jaxrs-api_2.1_spec>1.0.2.Final</version.org.jboss.spec.javax.ws.rs.jboss-jaxrs-api_2.1_spec>
+    <version.org.jboss.spec.javax.ws.rs.jboss-jaxrs-api_2.1_spec>2.0.1.Final</version.org.jboss.spec.javax.ws.rs.jboss-jaxrs-api_2.1_spec>
     <version.org.apache.maven.plugins.dependency>3.0.2</version.org.apache.maven.plugins.dependency>
 
     <version.org.postgresql>9.4.1207</version.org.postgresql>
@@ -792,6 +792,8 @@
                       <ignoreClass>com.google.gwt.uibinder.rebind.UiBinderGenerator</ignoreClass>
                       <!-- ignoring java 9 compatible class for modules -->
                       <ignoreClass>module-info</ignoreClass>
+                      <!-- ignoring multirelease jar classes -->
+                      <ignoreClass>META-INF/versions/*</ignoreClass>
                       <!-- Classes repackaged in the maven world-->
                       <ignoreClass>org.eclipse.aether.*</ignoreClass>
                       <ignoreClass>org.apache.maven.*</ignoreClass>
@@ -873,6 +875,14 @@
                           </ignoreClass>
                           <ignoreClass>io.fabric8.kubernetes.client.ConfigFluentImpl
                           </ignoreClass>
+                        </ignoreClasses>
+                      </dependency>
+                      <dependency>
+                        <groupId>org.jboss.marshalling</groupId>
+                        <artifactId>jboss-marshalling-osgi</artifactId>
+                        <type>jar</type>
+                        <ignoreClasses>
+                          <ignoreClass>org.jboss.marshalling.*</ignoreClass>
                         </ignoreClasses>
                       </dependency>
                     </dependencies>


### PR DESCRIPTION
second attempt to find out why Enforcer errors for ban-duplicated-classes is not shown on FDB

Merge together with:
- https://github.com/kiegroup/appformer/pull/983
- https://github.com/kiegroup/jbpm/pull/1670
- https://github.com/kiegroup/droolsjbpm-integration/pull/2121
- https://github.com/kiegroup/kie-wb-common/pull/3320
- https://github.com/kiegroup/jbpm-wb/pull/1439
- https://github.com/kiegroup/kie-wb-distributions/pull/1037
