### PR TITLE
Upgrade Plexus, Maven, sisu, httpclient, guava, guice, cli, codec, asm, jupiter and jandex

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,12 +54,12 @@
       - Version properties must be sorted alphabetically (other form of sorting were found to be unclear and ambiguous).
     -->
     <version.aopalliance>1.0</version.aopalliance>
-    <version.asm>3.3.1</version.asm>
+    <version.asm>7.3.1</version.asm>
     <version.ch.qos.cal10n>0.8.1</version.ch.qos.cal10n>
     <version.ch.qos.logback>1.2.3</version.ch.qos.logback>
     <version.commons-beanutils>1.9.4</version.commons-beanutils>
-    <version.commons-cli>1.3.1</version.commons-cli>
-    <version.commons-codec>1.11</version.commons-codec>
+    <version.commons-cli>1.4</version.commons-cli>
+    <version.commons-codec>1.13</version.commons-codec>
     <version.commons-collections>3.2.2</version.commons-collections>
     <version.commons-configuration>1.6</version.commons-configuration>
     <version.commons-dbcp>1.4</version.commons-dbcp>
@@ -77,8 +77,8 @@
     <version.com.fasterxml.jackson>2.9.10</version.com.fasterxml.jackson>
     <version.com.fasterxml.jackson.databind>2.9.10.4</version.com.fasterxml.jackson.databind>
     <version.com.google.code.gson>2.8.2</version.com.google.code.gson>
-    <version.com.google.guava>25.0-jre</version.com.google.guava>
-    <version.com.google.inject.guice>4.0</version.com.google.inject.guice>
+    <version.com.google.guava>27.0.1-jre</version.com.google.guava>
+    <version.com.google.inject.guice>4.2.1</version.com.google.inject.guice>
     <version.com.google.gwt>2.8.2</version.com.google.gwt>
     <version.org.google.gwt-charts>0.9.9</version.org.google.gwt-charts>
     <version.com.google.gwt.gwtmockito>1.1.8</version.com.google.gwt.gwtmockito>
@@ -135,13 +135,13 @@
     <version.org.apache.commons.ssl>0.3.9</version.org.apache.commons.ssl>
     <version.org.apache.deltaspike.core>1.5.1</version.org.apache.deltaspike.core>
     <version.org.apache.ftpserver>1.0.6</version.org.apache.ftpserver>
-    <version.org.apache.httpcomponents.httpclient>4.5.4</version.org.apache.httpcomponents.httpclient>
-    <version.org.apache.httpcomponents.httpcore>4.4.6</version.org.apache.httpcomponents.httpcore>
+    <version.org.apache.httpcomponents.httpclient>4.5.12</version.org.apache.httpcomponents.httpclient>
+    <version.org.apache.httpcomponents.httpcore>4.4.13</version.org.apache.httpcomponents.httpcore>
     <version.org.apache.karaf>2.4.0</version.org.apache.karaf>
     <version.org.apache.lucene>6.6.1</version.org.apache.lucene>
-    <version.org.apache.maven>3.3.9</version.org.apache.maven>
-    <version.org.apache.maven.plugin-tools>3.4</version.org.apache.maven.plugin-tools>
-    <version.org.apache.maven.wagon>3.0.0</version.org.apache.maven.wagon>
+    <version.org.apache.maven>3.6.3</version.org.apache.maven>
+    <version.org.apache.maven.plugin-tools>3.6.0</version.org.apache.maven.plugin-tools>
+    <version.org.apache.maven.wagon>3.3.3</version.org.apache.maven.wagon>
     <version.org.apache.neethi>3.1.1</version.org.apache.neethi>
     <version.org.apache.poi>4.1.2</version.org.apache.poi>
     <version.org.apache.sshd>1.6.0</version.org.apache.sshd>
@@ -157,10 +157,10 @@
     <version.org.codehaus.jackson>1.9.13</version.org.codehaus.jackson>
     <version.org.codehaus.janino>2.5.16</version.org.codehaus.janino>
     <version.org.codehaus.jettison>1.4.0</version.org.codehaus.jettison>
-    <version.org.codehaus.plexus.plexus-classworlds>2.5.2</version.org.codehaus.plexus.plexus-classworlds>
-    <version.org.codehaus.plexus.plexus-containers>1.6</version.org.codehaus.plexus.plexus-containers>
-    <version.org.codehaus.plexus.plexus-interpolation>1.21</version.org.codehaus.plexus.plexus-interpolation>
-    <version.org.codehaus.plexus.plexus-utils>3.0.22</version.org.codehaus.plexus.plexus-utils>
+    <version.org.codehaus.plexus.plexus-classworlds>2.6.0</version.org.codehaus.plexus.plexus-classworlds>
+    <version.org.codehaus.plexus.plexus-containers>2.1.0</version.org.codehaus.plexus.plexus-containers>
+    <version.org.codehaus.plexus.plexus-interpolation>1.25</version.org.codehaus.plexus.plexus-interpolation>
+    <version.org.codehaus.plexus.plexus-utils>3.2.1</version.org.codehaus.plexus.plexus-utils>
     <version.org.codehaus.woodstox>4.4.1</version.org.codehaus.woodstox>
     <version.org.easytesting.fest>2.0M6</version.org.easytesting.fest>
     <version.org.easymock>3.0</version.org.easymock>
@@ -172,7 +172,7 @@
     <version.org.eclipse.jetty>9.2.14.v20151106</version.org.eclipse.jetty>
     <version.org.eclipse.jgit>5.0.2.201807311906-r</version.org.eclipse.jgit>
     <version.org.eclipse.persistence>2.7.6</version.org.eclipse.persistence>
-    <version.org.eclipse.sisu>0.3.2</version.org.eclipse.sisu>
+    <version.org.eclipse.sisu>0.3.4</version.org.eclipse.sisu>
     <version.org.eclipse.emf.gwt>2.9.0</version.org.eclipse.emf.gwt>
     <version.org.glassfish>3.1.2</version.org.glassfish>
     <version.org.glassfish.jakarta>1.1.6</version.org.glassfish.jakarta>
@@ -230,8 +230,8 @@
     <version.org.jpmml.model>1.4.11
     </version.org.jpmml.model> <!-- jpmml-model BSD 3C license - ATTENTION 1.4.11 intentional, because 1.4.9 evaluators depend on 1.4.11 -->
     <version.org.json>20090211</version.org.json>
-    <version.org.jsoup>1.8.3</version.org.jsoup>
-    <version.org.junit>5.5.2</version.org.junit>
+    <version.org.jsoup>1.11.3</version.org.jsoup>
+    <version.org.junit>5.6.2</version.org.junit>
     <version.org.keycloak>4.8.3.Final</version.org.keycloak>
     <version.log4j>1.2.17</version.log4j>
     <version.org.mvel>2.4.7.Final</version.org.mvel>
@@ -249,7 +249,7 @@
     <version.org.slf4j>1.7.26</version.org.slf4j>
     <version.org.sonatype.aether>1.13.1</version.org.sonatype.aether>
     <version.org.sonatype.plexus.plexus-cipher>1.7</version.org.sonatype.plexus.plexus-cipher>
-    <version.org.sonatype.plexus.plexus-sec-dispatcher>1.3</version.org.sonatype.plexus.plexus-sec-dispatcher>
+    <version.org.sonatype.plexus.plexus-sec-dispatcher>1.4</version.org.sonatype.plexus.plexus-sec-dispatcher>
     <version.org.sonatype.sisu>2.3.0</version.org.sonatype.sisu>
     <version.org.sonatype.sisu.sisu-guice>3.2.3</version.org.sonatype.sisu.sisu-guice>
     <version.org.springframework>5.2.5.RELEASE</version.org.springframework>
@@ -261,7 +261,7 @@
     <version.org.wildfly>18.0.1.Final</version.org.wildfly>
     <version.org.wildfly.arquillian>2.2.0.Final</version.org.wildfly.arquillian>
     <version.org.wildfly.core>10.0.3.Final</version.org.wildfly.core>
-    <version.org.wildfly.common>1.5.1.Final</version.org.wildfly.common>
+    <version.org.wildfly.common>1.5.4.Final-format-001</version.org.wildfly.common>
     <version.org.yaml.snakeyaml>1.18</version.org.yaml.snakeyaml>
     <version.postgresql>8.4-702.jdbc4</version.postgresql>
     <version.org.mozilla.rhino>1.7R4</version.org.mozilla.rhino>
@@ -318,7 +318,7 @@
     <version.org.jboss.errai.wildfly>${version.org.wildfly}</version.org.jboss.errai.wildfly>
     <!-- Required by jboss-remoting version above -->
     <version.org.wildfly.security>1.10.4.Final</version.org.wildfly.security>
-    <version.org.ow2.asm>5.0.4</version.org.ow2.asm>
+    <version.org.ow2.asm>8.0.1</version.org.ow2.asm>
     <version.org.picketlink>2.6.0.Final</version.org.picketlink>
     <version.com.unboundid>3.2.0</version.com.unboundid>
     <version.com.wordnik.swagger>1.3.10</version.com.wordnik.swagger>
@@ -444,7 +444,7 @@
     <version.mariadb-java-client>1.3.4</version.mariadb-java-client>
 
     <version.ch.obermuhlner>2.0.1</version.ch.obermuhlner>
-    <version.org.jboss.jandex>2.1.1.Final</version.org.jboss.jandex>
+    <version.org.jboss.jandex>2.1.3.Final</version.org.jboss.jandex>
     <version.org.eclipse.yasson>1.0.6</version.org.eclipse.yasson>
     <version.javax.jws-api>1.1</version.javax.jws-api>
     <version.javax.xml.ws>2.3.1</version.javax.xml.ws>


### PR DESCRIPTION
Upgrades a bunch of components that haven't been updated in ages.
Experiment to see how much this breaks the downstream build :)

Open question:
- Are any of these components defined by WildFly/EAP? Which version do they use?