### PR TITLE
ECJ downgrade try

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -168,7 +168,7 @@
     <version.org.eclipse.aether>1.1.0</version.org.eclipse.aether>
     <version.org.eclipse.emf>2.6.0.v20100614-1136</version.org.eclipse.emf>
     <version.org.eclipse.emf.ecore.xmi>2.5.0.v20100521-1846</version.org.eclipse.emf.ecore.xmi>
-    <version.org.eclipse.jdt>3.19.0</version.org.eclipse.jdt>
+    <version.org.eclipse.jdt>3.18.0</version.org.eclipse.jdt>
     <version.org.eclipse.jetty>9.2.14.v20151106</version.org.eclipse.jetty>
     <version.org.eclipse.jgit>5.0.2.201807311906-r</version.org.eclipse.jgit>
     <version.org.eclipse.persistence>2.7.6</version.org.eclipse.persistence>


### PR DESCRIPTION
GWT 2.9 uses ECJ 3.18, would simplify quite a lot to normalize the use of it.