### PR TITLE
Upgrade Maven minimum version from 3.5.2 to 3.6.3

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ pipeline {
         label agentLabel
     }
     tools {
-        maven 'kie-maven-3.5.4'
+        maven 'kie-maven-3.6.3'
         jdk 'kie-jdk1.8'
     }
     options {

--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -5,7 +5,7 @@ pipeline {
         label 'kie-rhel7 && kie-mem24g && !master'
     }
     tools {
-        maven 'kie-maven-3.6.0'
+        maven 'kie-maven-3.6.3'
         jdk 'kie-jdk1.8'
     }
     parameters {

--- a/pom.xml
+++ b/pom.xml
@@ -393,7 +393,7 @@
     <!-- replaces findbugs-maven-plugin -->
     <version.com.github.spotbugs-maven-plugin>3.1.8</version.com.github.spotbugs-maven-plugin>
 
-    <maven.min.version>3.5.2</maven.min.version>
+    <maven.min.version>3.6.3</maven.min.version>
     <!-- Important: this is one and only place where the supported user agents (browsers) are configured.
          All webapps/showcases must use this property in their *.gwt.xml files.
          We only need to support IE11+, but there is no ie11 permutation. IE11 will use the Firefox one (gecko1_8) -->


### PR DESCRIPTION
because some parts of the build (optaplanner repo) are not compatible with the older version.

We'll have to announce this before merging.