### PR TITLE
DO NOT MERGE - Branch OptaPlanner 8 test Jenkins CI cross repo PR

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2119,6 +2119,14 @@
 
   <dependencyManagement>
     <dependencies>
+      <!-- DO NOT MERGE THIS -->
+      <!-- Test CI for Cross repository PR's over build-boostrap master and optaplanner 7.x -->
+      <dependency>
+        <groupId>org.guvnor</groupId>
+        <artifactId>guvnor-project-api</artifactId>
+        <version>7.4.1.Final</version>
+      </dependency>
+
       <!-- dependencies from jboss-ip-bom -->
       <!--
         CONVENTIONS:


### PR DESCRIPTION
This tests a cross repo PR towards build-bootstrap master and optaplanner 7.x. Do not merge. We'll close it when we're done.

PR's involved:

* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1379
* https://github.com/kiegroup/optaplanner/pull/818