### PR TITLE
echo in logs of correct branch for optaplanner when cloning master

### DIFF
--- a/script/git-clone-others.sh
+++ b/script/git-clone-others.sh
@@ -111,6 +111,7 @@ for repository in $REPOSITORY_LIST ; do
             if [[ ${additionalGitOptions[0]} == "-b" ]] || [[ ${additionalGitOptions[0]} == "--branch" ]]; then
                 if [[ ${additionalGitOptions[1]} == "master" ]]; then
                   repoAdditionalGitOptions[1]="7.x"
+                  echo -- additional Git options changed in ${repository} to: ${repoAdditionalGitOptions[@]} --
                 fi
             else
                 repoAdditionalGitOptions=( "-b" "7.x" "${repoAdditionalGitOptions[@]}" )


### PR DESCRIPTION
@ge0ffrey if not merged this commit it works properly and checks-out tha 7.x master branch but in logs still appear -b master. It is nicer to have this in the logs.