### PR TITLE
BXMSPROD-858: fix that clone script doesn't clone with --single-branc…

### DIFF
--- a/script/release/01_cloneBranches.sh
+++ b/script/release/01_cloneBranches.sh
@@ -4,4 +4,4 @@
 # parameter: baseBranch = $1
 
 # clone all repos except droolsjbpm-build-bootstrap as this is supposed to be cloned before this script and has to be available
-./droolsjbpm-build-bootstrap/script/git-clone-others.sh --branch $1 --depth 70
+./droolsjbpm-build-bootstrap/script/git-clone-others.sh --branch $1 --depth 70 --no-single-branch


### PR DESCRIPTION
…h (default value unless --no-single-branch is specified)

**@all** :  thanx to @almope help we could figure out why the JIRA [BXMSPROD-858l](https://issues.redhat.com/browse/BXMSPROD-858l) happens.
The missing parameter --no-single-branch in the 01_cloneBranches.sh  script makes that not only a single branch of a remote is cloned.