### PR TITLE
makes script fail when optaplanner is not checked out to 7.x branch

### DIFF
--- a/script/release/update-version-all.sh
+++ b/script/release/update-version-all.sh
@@ -89,6 +89,43 @@ startDateTime=`date +%s`
 
 cd $droolsjbpmOrganizationDir
 
+# --- --- ---
+# checks if optaplanner is on the right 7.x branch if all other repos are checked out to master
+# optaplanner 7.x branch has the same version as master on other kiegroup/reps
+cd optaplanner
+optaBranch=$(git rev-parse --abbrev-ref HEAD)
+if [ $optaBranch == "master" ]; then
+    echo ""
+    echo "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
+	echo " Can't update versions for master branches because optaplanner is still on master and should be checked out to 7.x"
+	echo ""
+    while true; do
+        echo "a abort"
+        echo "c continue and check out optaplanner to 7.x"
+        echo ""
+        echo -n "Do you want to continue c or abort a "
+        echo ""
+        read choice
+
+        case $choice in
+            c)
+            git checkout 7.x
+            break
+            ;;
+            a)
+            echo "-------------------------- ABORTED --------------------------"
+            echo "+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
+            exit 0;
+            ;;
+            *)
+            echo "That is not a valid choice, try a c to continue or a to abort"
+            ;;
+        esac
+    done
+fi
+cd ..
+# --- --- ---
+
 for repository in `cat ${scriptDir}/../repository-list.txt` ; do
     echo
 


### PR DESCRIPTION
If optaplanner is checked out to **master** the update-version-all script will fail.
optaplanner has to be checked out to **7.x** when all other reps are checked out to master.
Problem we had: when all reps where checked out to **master** and the script run, optaplanner **master** was updated and lost his version **8.0.0-SNAPSHOT**. 
The optaplanner 7.x should have always the same version as all other **master** branches.