### PR TITLE
JBPM-9227: upgrade maven cargo plugin for newer Wildlfy 19 container

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -305,7 +305,7 @@
     <version.org.antlr4>4.8</version.org.antlr4>
     <version.org.apache.cxf>3.2.12</version.org.apache.cxf>
     <version.org.apache.camel>2.24.0</version.org.apache.camel>
-    <version.org.codehaus.cargo>1.7.9</version.org.codehaus.cargo>
+    <version.org.codehaus.cargo>1.7.11</version.org.codehaus.cargo>
     <version.org.freemarker>2.3.28</version.org.freemarker>
     <!-- Dependencies for selenium tests -->
     <version.org.jboss.arquillian.selenium>3.13.0</version.org.jboss.arquillian.selenium>


### PR DESCRIPTION
https://issues.redhat.com/browse/JBPM-9227

Merge together with:
- https://github.com/kiegroup/jbpm/pull/1696
- https://github.com/kiegroup/droolsjbpm-integration/pull/2150
- https://github.com/kiegroup/kie-wb-distributions/pull/1045
