### PR TITLE
removes kie-pmml-integration for all PRs as upstream rep

### DIFF
--- a/pullrequest.stages
+++ b/pullrequest.stages
@@ -7,6 +7,7 @@ stage('Pull Request Build') {
         println "Reading file ${REPOSITORY_LIST_FILE}"
         def file = readFile REPOSITORY_LIST_FILE
         def projectCollection = file.readLines()
+        projectCollection.removeAll(['kie-jpmml-integration'])
         def gitURL = env.ghprbAuthorRepoGitUrl ?: env.GIT_URL
         def project = util.getProjectGroupName(util.getProject(gitURL))[1]
 


### PR DESCRIPTION
this should remove kie-jpmml-integration as upstream project for all PRs.
If this is also wanted for FDBs and CDB this line: 
**projectCollection.removeAll(['kie-jpmml-integration'])**
should be added to [FDB stages](https://github.com/kiegroup/droolsjbpm-build-bootstrap/blob/master/downstream.stages) and [CDB stages](https://github.com/kiegroup/droolsjbpm-build-bootstrap/blob/master/compilation.stages)