### PR TITLE
JBPM-9231: upgrade to the latest Apache Batik 1.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,8 +150,8 @@
     <version.org.apache.velocity>1.7</version.org.apache.velocity>
     <version.org.apache.xmlbeans>3.1.0</version.org.apache.xmlbeans>
     <version.org.apache.ws.xmlschema>2.2.4</version.org.apache.ws.xmlschema>
-    <version.org.apache.xmlgraphics.batik>1.9.1</version.org.apache.xmlgraphics.batik>
-    <version.org.apache.xmlgraphics.commons>2.2</version.org.apache.xmlgraphics.commons>
+    <version.org.apache.xmlgraphics.batik>1.13</version.org.apache.xmlgraphics.batik>
+    <version.org.apache.xmlgraphics.commons>2.4</version.org.apache.xmlgraphics.commons>
     <version.org.assertj>3.14.0</version.org.assertj>
     <version.org.codehaus.btm>2.1.4</version.org.codehaus.btm>
     <version.org.codehaus.groovy>2.0.5</version.org.codehaus.groovy>


### PR DESCRIPTION
https://issues.redhat.com/browse/JBPM-9231

There is new version of Apache Batik 1.13

Merge together with https://github.com/kiegroup/droolsjbpm-integration/pull/2183 and https://github.com/kiegroup/jbpm-designer/pull/885