### PR TITLE
BXMSPROD-881 shared libraries pointing to 7.39.x

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('jenkins-pipeline-shared-libraries')_
+@Library('jenkins-pipeline-shared-libraries@7.39.x')_
 
 agentLabel = "${env.ADDITIONAL_LABEL?.trim() ? ADDITIONAL_LABEL : 'kie-rhel7 && kie-mem24g'} && !master"
 additionalArtifactsToArchive = "${env.ADDITIONAL_ARTIFACTS_TO_ARCHIVE?.trim() ?: ''}"

--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -1,4 +1,4 @@
-@Library('jenkins-pipeline-shared-libraries')_
+@Library('jenkins-pipeline-shared-libraries@7.39.x')_
 
 pipeline {
     agent {


### PR DESCRIPTION
https://issues.redhat.com/browse/BXMSPROD-881
just adding `@7.39.x` (being 7.39.x the branch name from the library's repo) Jenkins will take version from there
https://github.com/kiegroup/jenkins-pipeline-shared-libraries/tree/7.39.x
A new job has been created in order to automatize it https://rhba-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/PROD/job/replace-jenkins-pipeline-shared-libraries/
@mbiarnes will add jenkins-pipeline-shared-libraries to branch creation and will call the new job after creating branches.

related with: https://github.com/jboss-integration/rhba/pull/28