### PR TITLE
[DROOLS-5143] Declaring Mining Model modules version

### DIFF
--- a/kie-pmml-bom/pom.xml
+++ b/kie-pmml-bom/pom.xml
@@ -156,6 +156,22 @@
         <artifactId>kie-pmml-models-drools-scorecard-evaluator</artifactId>
         <version>${version.org.kie}</version>
       </dependency>
+      <!-- Mining -->
+      <dependency>
+        <groupId>org.kie</groupId>
+        <artifactId>kie-pmml-models-mining-model</artifactId>
+        <version>${version.org.kie}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.kie</groupId>
+        <artifactId>kie-pmml-models-mining-compiler</artifactId>
+        <version>${version.org.kie}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.kie</groupId>
+        <artifactId>kie-pmml-models-mining-evaluator</artifactId>
+        <version>${version.org.kie}</version>
+      </dependency>
       <!-- EXTERNAL -->
       <!-- TEST -->
       <dependency>


### PR DESCRIPTION
@danielezonca @jiripetrlik

see https://issues.redhat.com/browse/DROOLS-5143

This first step is just declaring Mining model modules inside kie-pmml dependencies bom