### PR TITLE
BXMSPROD-911 adapted to take forked projects with different name

### DIFF
--- a/.ci/compilation.stages
+++ b/.ci/compilation.stages
@@ -8,9 +8,7 @@ def call(def propertiesFolderPath) {
             def file = readFile REPOSITORY_LIST_FILE
             def projectCollection = file.readLines()
             projectCollection.removeAll(['kie-jpmml-integration','droolsjbpm-tools', 'kie-docs'])
-            def gitURL = env.ghprbAuthorRepoGitUrl ?: env.GIT_URL
-            def project = util.getProjectGroupName(util.getProject(gitURL))[1]
-            compile.build(projectCollection, project, "${SETTINGS_XML_ID}", "${PROPERTIES_FILE_PATH}")
+            compile.build(projectCollection, util.getCurrentProjectName(), "${SETTINGS_XML_ID}", "${PROPERTIES_FILE_PATH}")
         }
     }
 }

--- a/.ci/new.downstream.stages
+++ b/.ci/new.downstream.stages
@@ -7,10 +7,8 @@ def call(def propertiesFolderPath) {
             println "Reading file ${REPOSITORY_LIST_FILE}"
             def file = readFile REPOSITORY_LIST_FILE
             def projectCollection = file.readLines()
-            def gitURL = env.ghprbAuthorRepoGitUrl ?: env.GIT_URL
-            def project = util.getProjectGroupName(util.getProject(gitURL))[1]
             projectCollection.removeAll(['droolsjbpm-tools', 'kie-docs'])
-            compile.build(projectCollection, project, "${SETTINGS_XML_ID}", "${PROPERTIES_FILE_PATH}")
+            compile.build(projectCollection, util.getCurrentProjectName(), "${SETTINGS_XML_ID}", "${PROPERTIES_FILE_PATH}")
         }
     }
 }

--- a/.ci/pullrequest.stages
+++ b/.ci/pullrequest.stages
@@ -9,8 +9,7 @@ def call(def propertiesFolderPath) {
             def file = readFile REPOSITORY_LIST_FILE
             def projectCollection = file.readLines()
             projectCollection.removeAll(['kie-jpmml-integration'])
-            def gitURL = env.ghprbAuthorRepoGitUrl ?: env.GIT_URL
-            def project = util.getProjectGroupName(util.getProject(gitURL))[1]
+            def project = util.getCurrentProjectName()
             if (project != "kie-docs") {
                 pullrequest.build(projectCollection, project, "${SETTINGS_XML_ID}", "${PROPERTIES_FILE_PATH}", "${SONARCLOUD_ID}", ["optaplanner", "drools", "appformer", "jbpm", "drools-wb", "kie-soup", "droolsjbpm-integration", "kie-wb-common", "openshift-drools-hacep", "optaweb-employee-rostering"])
             } else {

--- a/.ci/upstream.stages
+++ b/.ci/upstream.stages
@@ -7,10 +7,7 @@ def call(def propertiesFolderPath) {
             def file = readFile REPOSITORY_LIST_FILE
             def projectCollection = file.readLines()
             projectCollection.removeAll(['kie-jpmml-integration'])
-            def gitURL = env.ghprbAuthorRepoGitUrl ?: env.GIT_URL
-            def project = util.getProjectGroupName(util.getProject(gitURL))[1]
-
-            treebuild.upstreamBuild(projectCollection, project, "${SETTINGS_XML_ID}", 'clean install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true')
+            treebuild.upstreamBuild(projectCollection, util.getCurrentProjectName(), "${SETTINGS_XML_ID}", 'clean install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true')
         }
     }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/BXMSPROD-911
depends on https://github.com/kiegroup/jenkins-pipeline-shared-libraries/pull/94
Test job https://rhba-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/KIE/job/master/job/pullrequest/job/new-PR-optaweb-employee-rostering-master.pullrequests/31

The `Linux - Pull Request` result is not right since https://github.com/kiegroup/jenkins-pipeline-shared-libraries/pull/94 was not merged at the time the job was triggered 