### PR TITLE
[JBPM-9269] ibm jdk: Missing sun.security classes for mock-server tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -153,6 +153,7 @@
     <version.org.apache.xmlgraphics.batik>1.9.1</version.org.apache.xmlgraphics.batik>
     <version.org.apache.xmlgraphics.commons>2.2</version.org.apache.xmlgraphics.commons>
     <version.org.assertj>3.14.0</version.org.assertj>
+    <version.org.bouncycastle>1.65</version.org.bouncycastle>
     <version.org.codehaus.btm>2.1.4</version.org.codehaus.btm>
     <version.org.codehaus.groovy>2.0.5</version.org.codehaus.groovy>
     <version.org.codehaus.jackson>1.9.13</version.org.codehaus.jackson>
@@ -479,7 +480,7 @@
     <version.org.kogito.gwt-jsonix-schema-compiler>1.2.1</version.org.kogito.gwt-jsonix-schema-compiler>
     <version.org.hisrc.jsonix.jsonix-scripts>3.0.0</version.org.hisrc.jsonix.jsonix-scripts>
     <version.org.jvnet.jaxb2.maven2.maven-jaxb2-plugin>0.14.0</version.org.jvnet.jaxb2.maven2.maven-jaxb2-plugin>
-    <version.org.mock-server>5.10.0</version.org.mock-server>
+    <version.org.mock-server>5.11.1</version.org.mock-server>
   </properties>
 
   <repositories>
@@ -5300,6 +5301,21 @@
             <artifactId>jaxb-api</artifactId>
           </exclusion>
         </exclusions>
+        <scope>test</scope>
+      </dependency>
+      
+      <!-- Used by jbpm-workitems-rest -->
+      <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bcprov-jdk15on</artifactId>
+        <version>${version.org.bouncycastle}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bcpkix-jdk15on</artifactId>
+        <version>${version.org.bouncycastle}</version>
+        <scope>test</scope>
       </dependency>
 
       <!-- Used by kie-pmml-trusty projects -->


### PR DESCRIPTION
Merge together with https://github.com/kiegroup/jbpm/pull/1719