### PR TITLE
BAPL-678: BPMN Editor - Syntax Highlighting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -263,6 +263,7 @@
     <version.org.subethamail>1.2</version.org.subethamail>
     <version.org.subethamail.subethasmtp>3.1.6</version.org.subethamail.subethasmtp>
     <version.org.webjars.swagger-ui>2.2.10</version.org.webjars.swagger-ui>
+    <version.org.webjars.npm.monaco-editor>0.20.0</version.org.webjars.npm.monaco-editor>
     <version.org.wildfly>19.1.0.Final</version.org.wildfly>
     <version.org.wildfly.arquillian>2.2.0.Final</version.org.wildfly.arquillian>
     <version.org.wildfly.core>10.0.3.Final</version.org.wildfly.core>


### PR DESCRIPTION
Hey @ederign @karreiro 

Just moving from `appformer-parent` to `kie-parent` the version of the monaco editor webjar, so it can be also used by the BPMN editor.

Thanks!

Assembly:
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1429
- https://github.com/kiegroup/appformer/pull/1012
- https://github.com/kiegroup/kie-wb-common/pull/3372