### PR TITLE
Upgrade to Netty 4.1.51.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -366,7 +366,7 @@
     <!-- Make OSGi happy -->
     <osgi.snapshot.qualifier>${maven.build.timestamp}</osgi.snapshot.qualifier>
 
-    <version.io.netty>4.1.46.Final</version.io.netty>
+    <version.io.netty>4.1.51.Final</version.io.netty>
     <!-- IMPORTANT: Don't use this dependency. The right dependency version is the one named as "version.io.netty".
          This is just needed by Elasticsearch Transport Plugin because it has a compatibility mode with netty 3 and
          it can't be removed -->


### PR DESCRIPTION
- Update netty 4.1.51 which includes both security fixes and AArch64 performance improvements
- Refer release notes for detail:
  - https://netty.io/news/2020/05/13/4-1-50-Final.html
  - https://netty.io/news/2020/07/09/4-1-51-Final.html