### PR TITLE
Upgrade XStream to the latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
     <!-- Only used by optaweb-vehicle-routing, but is required -->
     <version.com.neovisionaries>1.27</version.com.neovisionaries>
     <version.com.sun.xml.bind>2.3.0</version.com.sun.xml.bind>
-    <version.com.thoughtworks.xstream>1.4.11.1</version.com.thoughtworks.xstream>
+    <version.com.thoughtworks.xstream>1.4.13</version.com.thoughtworks.xstream>
     <version.de.benediktmeurer.gwt-slf4j>0.0.2</version.de.benediktmeurer.gwt-slf4j>
     <version.org.dom4j>2.1.3</version.org.dom4j>
     <version.io.springfox>2.9.2</version.io.springfox>


### PR DESCRIPTION
The version 1.4.13 contains a fix that reduces warnings
about "illegal reflective access" on JDK 11 and above.


<pre>
How to retest a PR or trigger a specific build:

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</pre>
