### PR TITLE
BXMSPROD-1004: Add optawebs on the 7.x branch list

### DIFF
--- a/script/branched-7-repository-list.txt
+++ b/script/branched-7-repository-list.txt
@@ -1,1 +1,3 @@
 optaplanner
+optaweb-employee-rostering
+optaweb-vehicle-routing

--- a/script/release/update-version-all.sh
+++ b/script/release/update-version-all.sh
@@ -90,40 +90,42 @@ startDateTime=`date +%s`
 cd $droolsjbpmOrganizationDir
 
 # --- --- ---
-# checks if optaplanner is on the right 7.x branch if all other repos are checked out to master
-# optaplanner 7.x branch has the same version as master on other kiegroup/reps
-cd optaplanner
-optaBranch=$(git rev-parse --abbrev-ref HEAD)
-if [ $optaBranch == "master" ]; then
+# Checks if repos in branched-7-repository-list.txt are on the right 7.x branch if all other repos are checked out to master.
+# For example, optaplanner 7.x branch has the same version as master on other kiegroup/reps.
+for branch7xRepo in $(cat "${scriptDir}/../branched-7-repository-list.txt"); do
+  cd $branch7xRepo
+  currentBranch=$(git rev-parse --abbrev-ref HEAD)
+  if [ $currentBranch == "master" ]; then
+      echo ""
+      echo "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
+    echo " Can't update versions for master branches because $branch7xRepo is still on master and should be checked out to 7.x"
     echo ""
-    echo "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
-	echo " Can't update versions for master branches because optaplanner is still on master and should be checked out to 7.x"
-	echo ""
-    while true; do
-        echo "a abort"
-        echo "c continue and check out optaplanner to 7.x"
-        echo ""
-        echo -n "Do you want to continue c or abort a "
-        echo ""
-        read choice
+      while true; do
+          echo "a abort"
+          echo "c continue and check out $branch7xRepo to 7.x"
+          echo ""
+          echo -n "Do you want to continue c or abort a "
+          echo ""
+          read choice
 
-        case $choice in
-            c)
-            git checkout 7.x
-            break
-            ;;
-            a)
-            echo "-------------------------- ABORTED --------------------------"
-            echo "+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
-            exit 0;
-            ;;
-            *)
-            echo "That is not a valid choice, try a c to continue or a to abort"
-            ;;
-        esac
-    done
-fi
-cd ..
+          case $choice in
+              c)
+              git checkout 7.x
+              break
+              ;;
+              a)
+              echo "-------------------------- ABORTED --------------------------"
+              echo "+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
+              exit 0;
+              ;;
+              *)
+              echo "That is not a valid choice, try a c to continue or a to abort"
+              ;;
+          esac
+      done
+  fi
+  cd ..
+done
 # --- --- ---
 
 for repository in `cat ${scriptDir}/../repository-list.txt` ; do


### PR DESCRIPTION
**JIRA**: https://issues.redhat.com/browse/BXMSPROD-1004

realted to:
https://github.com/kiegroup/optaweb-vehicle-routing/pull/368
https://github.com/kiegroup/optaweb-employee-rostering/pull/499
https://github.com/kiegroup/kie-docs/pull/2850
https://github.com/kiegroup/kie-wb-distributions/pull/1063

### Details
- Adds `optaweb-employee-rostering` and `optaweb-vehicle-routing` repos on the 7.x branched repo list.
- Updates the `update-version-all.sh` script to read from the list above and check if 7.x is checked out for all repos on that list.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
