### PR TITLE
BXMSPROD-996 remove multithread build for appformer, drools and kie-wb-common

### DIFF
--- a/.ci/compileDownstreamBuild.properties
+++ b/.ci/compileDownstreamBuild.properties
@@ -1,4 +1,7 @@
 goals.default.upstream=-e --builder smart -T1C clean install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true
+goals.appformer.upstream=-e clean install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true
+goals.drools.upstream=-e clean install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true
+goals.kie-wb-common.upstream=-e clean install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true
 goals.optaplanner.upstream=-e clean install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true
 goals.default.current=-e -fae -nsu --builder smart --builder smart -T1C clean install -Dfull -DskipTests
 goals.optaplanner.current=-e -fae -nsu clean install -Dfull -DskipTests

--- a/.ci/fullDownstreamBuild.properties
+++ b/.ci/fullDownstreamBuild.properties
@@ -1,4 +1,7 @@
 goals.default.upstream=-e --builder smart -T1C clean install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true
+goals.appformer.upstream=-e clean install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true
+goals.drools.upstream=-e clean install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true
+goals.kie-wb-common.upstream=-e clean install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true
 goals.optaplanner.upstream=-e clean install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true
 goals.default.current=-e -nsu --builder smart -T1C clean install -Dfull -DskipTests
 goals.optaplanner.current=-e -nsu clean install -Dfull -DskipTests

--- a/.ci/pullrequest.properties
+++ b/.ci/pullrequest.properties
@@ -1,6 +1,9 @@
 goals.default.current=-e -nsu -Dfull -Pwildfly clean install -Prun-code-coverage  -Dcontainer.profile=wildfly -Dcontainer=wildfly -Dintegration-tests=true -Dmaven.test.failure.ignore=true
 goals.droolsjbpm-integration.current=-e -nsu -Dfull -Pwildfly clean install -Pjenkins-pr-builder -Prun-code-coverage  -Dcontainer.profile=wildfly -Dcontainer=wildfly -Dintegration-tests=true -Dmaven.test.failure.ignore=true
 goals.default.upstream=-e --builder smart -T1C clean install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true
+goals.appformer.upstream=-e clean install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true
+goals.drools.upstream=-e clean install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true
+goals.kie-wb-common.upstream=-e clean install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true
 goals.optaplanner.upstream=-e clean install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true
 goals.default.sonarcloud=-nsu generate-resources -Psonarcloud-analysis
 goals.kie-docs.current=clean install


### PR DESCRIPTION
**Thank you for submitting this pull request**

https://issues.redhat.com/browse/BXMSPROD-996

https://github.com/kiegroup/appformer/pull/1056
https://github.com/kiegroup/drools/pull/3118
https://github.com/kiegroup/kie-wb-common/pull/3429
https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1476

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
