### PR TITLE
removed managed log4j:log4j dependency as not used

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -237,7 +237,6 @@
     <version.org.jsoup>1.8.3</version.org.jsoup>
     <version.org.junit>5.5.2</version.org.junit>
     <version.org.keycloak>9.0.3</version.org.keycloak>
-    <version.log4j>1.2.17</version.log4j>
     <version.org.apache.logging.log4j>2.13.2</version.org.apache.logging.log4j>
     <version.org.mvel>2.4.10.Final</version.org.mvel>
     <version.org.ocpsoft.prettytime>3.0.2.Final</version.org.ocpsoft.prettytime>
@@ -2656,30 +2655,6 @@
         <groupId>org.junit.vintage</groupId>
         <artifactId>junit-vintage-engine</artifactId>
         <version>${version.org.junit}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>log4j</groupId>
-        <artifactId>log4j</artifactId>
-        <version>${version.log4j}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>ant</groupId>
-            <artifactId>ant-nodeps</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>ant-contrib</groupId>
-            <artifactId>ant-contrib</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>ant</groupId>
-            <artifactId>ant-junit</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>sun.jdk</groupId>
-            <artifactId>tools</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
There is not used `log4j:log4j` dependency management. We and other dependencies uses `org.apache.logging.log4j` groupId which is next major version of the library.

This is an evidence  https://github.com/jboss-integration/jboss-integration-platform-bom/commit/a551c6c04d6af64f8f8d21e74ccf152c9a3d6133#diff-600376dffeb79835ede4a0b285078036R231 that the version property and dependencyManagement https://github.com/jboss-integration/jboss-integration-platform-bom/commit/a551c6c04d6af64f8f8d21e74ccf152c9a3d6133#diff-600376dffeb79835ede4a0b285078036R1948-R1953 were added for purpose of Modeshape project, which is not related to kiegroup projects.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
