### PR TITLE
BXMSPROD-1011 Jenkinsfile expected job names replaced

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,9 +38,9 @@ pipeline {
         stage('Build projects') {
             steps {
                 script {
-                    def file =  (JOB_NAME =~ /\/[a-z,A-Z\-0-9\.]*\.downstream\.production/).find() ? 'downstream.production.stages' :
-                                (JOB_NAME =~ /\/[a-z,A-Z\-0-9\.]*\.downstream/).find() ? 'fullDownstream.stages' :
-                                (JOB_NAME =~ /\/[a-z,A-Z\-0-9\.]*\.pullrequest/).find() ? 'pullrequest.stages' :
+                    def file =  (JOB_NAME =~ /\/[a-z,A-Z\-0-9\.]*\.fdbp/).find() ? 'downstream.production.stages' :
+                                (JOB_NAME =~ /\/[a-z,A-Z\-0-9\.]*\.fdb/).find() ? 'fullDownstream.stages' :
+                                (JOB_NAME =~ /\/[a-z,A-Z\-0-9\.]*\.pr/).find() ? 'pullrequest.stages' :
                                 (JOB_NAME =~ /\/[a-z,A-Z\-0-9\.]*\.compile/).find() ? 'compilation.stages' :
                                 'upstream.stages'
                     if(fileExists("$WORKSPACE/.ci/${file}")) {


### PR DESCRIPTION
**Thank you for submitting this pull request**

**JIRA**:

https://issues.redhat.com/browse/BXMSPROD-1011

**referenced Pull Requests**: 
* https://github.com/kiegroup/kie-jenkins-scripts/pull/821

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
