### PR TITLE
JBPM-9396: jbpm-work-items repository order changed

### DIFF
--- a/script/repository-list.txt
+++ b/script/repository-list.txt
@@ -8,6 +8,7 @@ drools
 optaplanner
 jbpm
 kie-jpmml-integration
+jbpm-work-items
 droolsjbpm-integration
 openshift-drools-hacep
 droolsjbpm-tools
@@ -17,7 +18,6 @@ kie-wb-common
 drools-wb
 optaplanner-wb
 jbpm-designer
-jbpm-work-items
 jbpm-wb
 kie-docs
 optaweb-employee-rostering


### PR DESCRIPTION
modules from jbpm-work-items are referenced in droolsjbpm-integrations repository

https://issues.redhat.com/browse/JBPM-9396

**referenced Pull Requests**: 
- the error was found on https://github.com/kiegroup/drools/pull/3066 CDB running.
- also nightly builds from master branch fails with this dependency error

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
