### PR TITLE
BXMSPROD-1024: droolsjbpm-tools is not any more excluded in reps for cdb

### DIFF
--- a/.ci/compilation.stages
+++ b/.ci/compilation.stages
@@ -7,7 +7,7 @@ def call(def propertiesFolderPath) {
             println "Reading file ${REPOSITORY_LIST_FILE}"
             def file = readFile REPOSITORY_LIST_FILE
             def projectCollection = file.readLines()
-            projectCollection.removeAll(['kie-jpmml-integration','droolsjbpm-tools', 'kie-docs'])
+            projectCollection.removeAll(['kie-jpmml-integration','kie-docs'])
             def gitURL = env.ghprbAuthorRepoGitUrl ?: env.GIT_URL
             def project = util.getProjectGroupName(util.getProject(gitURL))[1]
             compile.build(projectCollection, project, "${SETTINGS_XML_ID}", "${PROPERTIES_FILE_PATH}")


### PR DESCRIPTION
**Thank you for submitting this pull request**

**JIRA**: _(please edit the JIRA link if it exists)_ 

[link](https://www.example.com)

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* paste the link(s) from GitHub here
* link 2
* link 3 etc.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
