### PR TITLE
BAQE-1567 - Change revapi to check against 7.44.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -435,7 +435,7 @@
 
 
     <!-- Latest release to be used by api-compatibility-check to check backwards compatibility of the Kie API. -->
-    <revapi.oldKieVersion>7.39.0.Final</revapi.oldKieVersion>
+    <revapi.oldKieVersion>7.44.0.Final</revapi.oldKieVersion>
     <revapi.newKieVersion>${project.version}</revapi.newKieVersion>
 
     <version.org.jboss.spec.javax.websocket>1.1.3.Final</version.org.jboss.spec.javax.websocket>
@@ -995,6 +995,7 @@
                  we want even non breaking changes to be present. -->
             <reportSeverity>nonBreaking</reportSeverity>
             <failSeverity>potentiallyBreaking</failSeverity>
+            <failOnUnresolvedArtifacts>true</failOnUnresolvedArtifacts>
           </configuration>
           <!-- Running two executions is a workaround to make sure we get a HTML report in case revapi finds
                some incompatible changes. The "check" goal will simply fail the whole build before it could get


### PR DESCRIPTION
**Thank you for submitting this pull request**

**JIRA**: [BAQE-1567](https://issues.redhat.com/browse/BAQE-1567)

**referenced Pull Requests**: 

* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1485
* https://github.com/kiegroup/appformer/pull/1058
* https://github.com/kiegroup/droolsjbpm-knowledge/pull/467
* https://github.com/kiegroup/drools/pull/3132
* https://github.com/kiegroup/jbpm/pull/1764
* https://github.com/kiegroup/droolsjbpm-integration/pull/2255
* https://github.com/kiegroup/optaplanner/pull/953

Wait with merge until all valid repositories are good to go.

We now have to check against latest product release (7.8 DM/PAM) which means that we have to check against 7.39.0.Final community release.