### PR TITLE
BXMSPROD-1068: added separated scripts (drools, jbpm and optaplanner)…

### DIFF
--- a/script/release/10a_drools_upload_filemgmt.sh
+++ b/script/release/10a_drools_upload_filemgmt.sh
@@ -1,0 +1,80 @@
+#!/bin/bash -e
+
+# parameters: FILEMGMT_KEY = $1
+# fetch the <version.org.kie> from kie-parent-metadata pom.xml and set it on parameter KIE_VERSION
+kieVersion=$(sed -e 's/^[ \t]*//' -e 's/[ \t]*$//' -n -e 's/<version.org.kie>\(.*\)<\/version.org.kie>/\1/p' droolsjbpm-build-bootstrap/pom.xml)
+
+droolsDocs=drools@filemgmt.jboss.org:/docs_htdocs/drools/release
+droolsHtdocs=drools@filemgmt.jboss.org:/downloads_htdocs/drools/release
+uploadDir=${kieVersion}_uploadBinaries
+
+# create directory on filemgmt.jboss.org for new release
+touch upload_version
+echo "mkdir" $kieVersion > upload_version
+chmod +x upload_version
+sftp -i $1 -b upload_version $droolsDocs
+sftp -i $1 -b upload_version $droolsHtdocs
+
+#creates directories for updatesite for drools and jbpm on filemgmt.jboss.org
+touch upload_drools
+echo "mkdir org.drools.updatesite" > upload_drools
+chmod +x upload_drools
+sftp -i $1 -b upload_drools $droolsHtdocs/$kieVersion
+
+#creates directoy kie-api-javadoc for drools on filemgmt.jboss.org
+touch upload_kie_api_javadoc
+echo "mkdir kie-api-javadoc" > upload_kie_api_javadoc
+chmod +x upload_kie_api_javadoc
+sftp -i $1 -b upload_kie_api_javadoc $droolsDocs/$kieVersion
+
+#creates directory drools-docs on filemgmt.jboss.org
+touch upload_drools_docs
+echo "mkdir drools-docs" > upload_drools_docs
+chmod +x upload_drools_docs
+sftp -i $1 -b upload_drools_docs $droolsDocs/$kieVersion/
+
+
+
+# *** copies drools binaries and docs to filemgmt.jboss.org ********************************
+
+# bins
+scp -i $1 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $uploadDir/drools-distribution-$kieVersion.zip $droolsHtdocs/$kieVersion
+scp -i $1 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $uploadDir/droolsjbpm-integration-distribution-$kieVersion.zip $droolsHtdocs/$kieVersion
+scp -i $1 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $uploadDir/droolsjbpm-tools-distribution-$kieVersion.zip $droolsHtdocs/$kieVersion
+scp -i $1 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $uploadDir/business-central-$kieVersion-*.war $droolsHtdocs/$kieVersion
+scp -i $1 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $uploadDir/kie-server-distribution-$kieVersion.zip $droolsHtdocs/$kieVersion
+
+# updatesite
+scp -r -i -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $1 $uploadDir/updatesite/* $droolsHtdocs/$kieVersion/org.drools.updatesite
+
+# docs
+scp -r -i -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $1 $uploadDir/drools-docs/* $droolsDocs/$kieVersion/drools-docs
+scp -r -i -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $1 $uploadDir/kie-api-javadoc/* $droolsDocs/$kieVersion/kie-api-javadoc
+
+# make filemgmt symbolic links for drools
+mkdir filemgmt_links
+cd filemgmt_links
+
+###############################################################################
+# latest drools links
+###############################################################################
+touch ${kieVersion}
+ln -s ${kieVersion} latest
+
+echo "Uploading normal links..."
+rsync -e "ssh -i $1 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" --protocol=28 -a latest $droolsDocs
+rsync -e "ssh -i $1 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" --protocol=28 -a latest $droolsHtdocs
+
+###############################################################################
+# latestFinal drools links
+###############################################################################
+if [[ "${kieVersion}" == *Final* ]]; then
+    ln -s ${kieVersion} latestFinal
+    echo "Uploading Final links..."
+    rsync -e "ssh -i $1 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" --protocol=28 -a latestFinal $droolsDocs
+    rsync -e "ssh -i $1 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" --protocol=28 -a latestFinal $droolsHtdocs
+fi
+
+# remove files and directories for uploading drools
+rm upload_*
+rm -rf filemgmt_links

--- a/script/release/10b_jbpm_upload_filemgmt.sh
+++ b/script/release/10b_jbpm_upload_filemgmt.sh
@@ -1,0 +1,95 @@
+#!/bin/bash -e
+
+# parameters: FILEMGMT_KEY = $1
+# fetch the <version.org.kie> from kie-parent-metadata pom.xml and set it on parameter KIE_VERSION
+kieVersion=$(sed -e 's/^[ \t]*//' -e 's/[ \t]*$//' -n -e 's/<version.org.kie>\(.*\)<\/version.org.kie>/\1/p' droolsjbpm-build-bootstrap/pom.xml)
+
+jbpmDocs=jbpm@filemgmt.jboss.org:/docs_htdocs/jbpm/release
+jbpmHtdocs=jbpm@filemgmt.jboss.org:/downloads_htdocs/jbpm/release
+uploadDir=${kieVersion}_uploadBinaries
+
+# create directories on filemgmt.jboss.org for new release
+touch upload_version
+echo "mkdir" $kieVersion > upload_version
+chmod +x upload_version
+sftp -i $1 -b upload_version $jbpmDocs
+sftp -i $1 -b upload_version $jbpmHtdocs
+
+#creates directory updatesite for jbpm on filemgmt.jboss.org
+touch upload_jbpm
+echo "mkdir updatesite" > upload_jbpm
+chmod +x upload_jbpm
+sftp -i $1 -b upload_jbpm $jbpmHtdocs/$kieVersion
+
+# creates a directory service-repository for jbpm on filemgmt.jboss.org
+touch upload_service_repository
+echo "mkdir service-repository" > upload_service_repository
+chmod +x upload_service_repository
+sftp -i $1 -b upload_service_repository $jbpmHtdocs/$kieVersion
+
+#creates directories docs for jbpm on filemgmt.jboss.org
+touch upload_jbpm_docs
+echo "mkdir jbpm-docs" > upload_jbpm_docs
+chmod +x upload_jbpm_docs
+sftp -i $1 -b upload_jbpm_docs $jbpmDocs/$kieVersion
+
+# *** copies jbpm binaries and docs to filemgmt.jboss.org **********************************
+
+# bins
+scp -i $1 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $uploadDir/jbpm-$kieVersion-bin.zip $jbpmHtdocs/$kieVersion
+scp -i $1 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $uploadDir/jbpm-$kieVersion-examples.zip $jbpmHtdocs/$kieVersion
+scp -i $1 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $uploadDir/jbpm-server-$kieVersion-dist.zip $jbpmHtdocs/$kieVersion
+
+# uploads jbpm -installers them to filemgt.jboss.org
+uploadInstaller(){
+        # upload installers to filemgmt.jboss.org
+        scp -i $1 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null jbpm-installer-$kieVersion.zip $jbpmHtdocs/$kieVersion
+}
+
+uploadAllInstaller(){
+        # upload installers to filemgmt.jboss.org
+        scp -i $1 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null jbpm-installer-$kieVersion.zip $jbpmHtdocs/$kieVersion
+        # upload installers to filemgmt.jboss.org
+        scp -i $1 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null jbpm-installer-full-$kieVersion.zip $jbpmHtdocs/$kieVersion
+}
+
+if [[ $kieVersion == *"Final"* ]] ;then
+        uploadAllInstaller
+else
+        uploadInstaller
+fi
+
+# updatesite
+scp -r -i $1 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $uploadDir/updatesite/* $jbpmHtdocs/$kieVersion/updatesite
+
+# docs
+scp -r -i $1 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $uploadDir/jbpm-docs/* $jbpmDocs/$kieVersion/jbpm-docs
+scp -r -i $1 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $uploadDir/service-repository/* $jbpmHtdocs/$kieVersion/service-repository
+
+# make filemgmt symbolic links for jbpm
+mkdir filemgmt_links
+cd filemgmt_links
+
+###############################################################################
+# latest jbpm links
+###############################################################################
+touch ${kieVersion}
+ln -s ${kieVersion} latest
+
+echo "Uploading normal links..."
+rsync -e "ssh -i $1 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" --protocol=28 -a latest $jbpmDocs
+rsync -e "ssh -i $1 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" --protocol=28 -a latest $jbpmHtdocs
+
+###############################################################################
+# latestFinal jbpm links
+###############################################################################
+if [[ "${kieVersion}" == *Final* ]]; then
+    ln -s ${kieVersion} latestFinal
+    echo "Uploading Final links..."
+    rsync -e "ssh -i $1 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" --protocol=28 -a latestFinal $jbpmDocs
+    rsync -e "ssh -i $1 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" --protocol=28 -a latestFinal $jbpmHtdocs
+fi
+
+# remove files and directories for uploading drools
+rm upload_*
+rm -rf filemgmt_links

--- a/script/release/10c_optaplanner_upload_filemgmt.sh
+++ b/script/release/10c_optaplanner_upload_filemgmt.sh
@@ -1,0 +1,90 @@
+#!/bin/bash -e
+
+# parameters: FILEMGMT_KEY = $1
+# fetch the <version.org.kie> from kie-parent-metadata pom.xml and set it on parameter KIE_VERSION
+kieVersion=$(sed -e 's/^[ \t]*//' -e 's/[ \t]*$//' -n -e 's/<version.org.kie>\(.*\)<\/version.org.kie>/\1/p' Ajbpm-build-bootstrap/pom.xml)
+
+optaplannerDocs=optaplanner@filemgmt.jboss.org:/docs_htdocs/optaplanner/release
+optaplannerHtdocs=optaplanner@filemgmt.jboss.org:/downloads_htdocs/optaplanner/release
+uploadDir=${kieVersion}_uploadBinaries
+
+# create directories on filemgmt.jboss.org for new release
+touch upload_version
+echo "mkdir" $kieVersion > upload_version
+chmod +x upload_version
+sftp -i $1 -b upload_version $optaplannerDocs
+sftp -i $1 -b upload_version $optaplannerHtdocs
+
+# create directory optaplanner-docs for optaplanner on filemgmt.jboss.org
+touch upload_optaplanner_docs
+echo "mkdir optaplanner-docs" > upload_optaplanner_docs
+chmod +x upload_optaplanner_docs
+sftp -i $1 -b upload_optaplanner_docs $optaplannerDocs/$kieVersion
+
+# create directory optaweb-employee-rostering-docs for optaplanner on filemgmt.jboss.org
+touch upload_optaweb_employee_rostering_docs
+echo "mkdir optaweb-employee-rostering-docs" > upload_optaweb_employee_rostering_docs
+chmod +x upload_optaweb_employee_rostering_docs
+sftp -i $1 -b upload_optaweb_employee_rostering_docs $optaplannerDocs/$kieVersion
+
+# create directory optaweb-vehicle-routing-docs for optaplanner on filemgmt.jboss.org
+touch upload_optaweb-vehicle-routing-docs
+echo "mkdir optaweb-vehicle-routing-docs" > upload_optaweb-vehicle-routing-docs
+chmod +x upload_optaweb-vehicle-routing-docs
+sftp -i $1 -b upload_optaweb-vehicle-routing-docs $optaplannerDocs/$kieVersion
+
+# create directory optaplanner-javadoc for optaplanner on filemgmt.jboss.org
+touch upload_optaplanner_javadoc
+echo "mkdir optaplanner-javadoc" > upload_optaplanner_javadoc
+chmod +x upload_optaplanner_javadoc
+sftp -i $1 -b upload_optaplanner_javadoc $optaplannerDocs/$kieVersion
+
+# create directory optaplanner-wb-es-docs for optaplanner on filemgmt.jboss.org
+touch upload_optaplanner_wb_es_docs
+echo "mkdir optaplanner-wb-es-docs" > upload_optaplanner_wb_es_docs
+chmod +x upload_optaplanner_wb_es_docs
+sftp -i $1 -b upload_optaplanner_wb_es_docs $optaplannerDocs/$kieVersion
+
+# *** copies optaplanner binaries and docs to filemgmt.jboss.org ***************************
+
+# bins
+scp -i $1 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $uploadDir/optaplanner-distribution-$kieVersion.zip $optaplannerHtdocs/$kieVersion
+scp -i $1 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $uploadDir/optaweb-employee-rostering-distribution-$kieVersion.zip $optaplannerHtdocs/$kieVersion
+scp -i $1 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $uploadDir/optaweb-vehicle-routing-distribution-$kieVersion.zip $optaplannerHtdocs/$kieVersion
+
+# docs
+scp -r -i $1 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $uploadDir/optaplanner-docs/* $optaplannerDocs/$kieVersion/optaplanner-docs
+scp -r -i $1 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $uploadDir/optaweb-employee-rostering-docs/* $optaplannerDocs/$kieVersion/optaweb-employee-rostering-docs
+scp -r -i $1 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $uploadDir/optaweb-vehicle-routing-docs/* $optaplannerDocs/$kieVersion/optaweb-vehicle-routing-docs
+scp -r -i $1 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $uploadDir/optaplanner-javadoc/* $optaplannerDocs/$kieVersion/optaplanner-javadoc
+scp -r -i $1 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $uploadDir/optaplanner-wb-es-docs/* $optaplannerDocs/$kieVersion/optaplanner-wb-es-docs
+
+
+# make filemgmt symbolic links for optaplanner
+mkdir filemgmt_links
+cd filemgmt_links
+
+###############################################################################
+# latest optaplanner links
+###############################################################################
+touch ${kieVersion}
+ln -s ${kieVersion} latest
+
+echo "Uploading normal links..."
+rsync -e "ssh -i $1 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" --protocol=28 -a latest $optaplannerDocs
+rsync -e "ssh -i $1 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" --protocol=28 -a latest $optaplannerHtdocs
+
+###############################################################################
+# latestFinal optaplanner links
+###############################################################################
+if [[ "${kieVersion}" == *Final* ]]; then
+    ln -s ${kieVersion} latestFinal
+    echo "Uploading Final links..."
+    rsync -e "ssh -i $1 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" --protocol=28 -a latestFinal $optaplannerDocs
+    rsync -e "ssh -i $1 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" --protocol=28 -a latestFinal $optaplannerHtdocs
+fi
+
+# remove files and directories for uploading optaplanner
+rm upload_*
+rm -rf filemgmt_links
+


### PR DESCRIPTION
… for uploading binaries to filemgmt.jboss.org

(cherry picked from commit 9fbbc0ba9da609e9946841401f2ce9a0ef6f20b3)

**Thank you for submitting this pull request**

**JIRA**: _(please edit the JIRA link if it exists)_ 

[BXMSPROD-1068](https://issues.redhat.com/browse/BXMSPROD-1068)

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

https://github.com/kiegroup/kie-jenkins-scripts/pull/850
* link 2
* link 3 etc.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
