### PR TITLE
[DROOLS-5783] Make droolsjbpm-integration repo independent from appformer

### DIFF
--- a/kie-soup-bom/pom.xml
+++ b/kie-soup-bom/pom.xml
@@ -244,6 +244,17 @@
         <version>${project.version}</version>
         <classifier>sources</classifier>
       </dependency>
+      <dependency>
+        <groupId>org.kie.soup</groupId>
+        <artifactId>kie-soup-security-utils</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.kie.soup</groupId>
+        <artifactId>kie-soup-security-utils</artifactId>
+        <version>${project.version}</version>
+        <classifier>sources</classifier>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/script/repository-list.txt
+++ b/script/repository-list.txt
@@ -5,12 +5,12 @@ drools
 optaplanner
 jbpm
 kie-jpmml-integration
-lienzo-core
-lienzo-tests
-appformer
 droolsjbpm-integration
 openshift-drools-hacep
 droolsjbpm-tools
+lienzo-core
+lienzo-tests
+appformer
 kie-uberfire-extensions
 kie-wb-playground
 kie-wb-common

--- a/uberfire-bom/pom.xml
+++ b/uberfire-bom/pom.xml
@@ -138,17 +138,6 @@
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
-        <artifactId>uberfire-security-backend</artifactId>
-        <version>${version.org.uberfire}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.uberfire</groupId>
-        <artifactId>uberfire-security-backend</artifactId>
-        <version>${version.org.uberfire}</version>
-        <classifier>sources</classifier>
-      </dependency>
-      <dependency>
-        <groupId>org.uberfire</groupId>
         <artifactId>uberfire-security-client-backend</artifactId>
         <version>${version.org.uberfire}</version>
       </dependency>


### PR DESCRIPTION
https://issues.redhat.com/browse/DROOLS-5783

Description:
The goal of this PR is to cleanup `droolsjbpm-integration` repo from unnecessary relation with other repos (in this case `appformer`). It is a sort of followup of this PR https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1505 that tries to do the same but it has been partially reverted because of some remaining usages

Details of this part of the PR:
- adding `kie-soup-security-utils`
- removing `uberfire-security-backend`
- change `repository-list.txt` accordingly

@mareknovotny @Ginxo @lucamolteni @mariofusco 

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1517
* https://github.com/kiegroup/kie-soup/pull/163
* https://github.com/kiegroup/appformer/pull/1073
* https://github.com/kiegroup/droolsjbpm-integration/pull/2306
* https://github.com/kiegroup/kie-wb-common/pull/3472

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
