### PR TITLE
AF-2675: remove rep droolsjbpm-tools from builds and pipelines

### DIFF
--- a/.ci/project-dependencies.yaml
+++ b/.ci/project-dependencies.yaml
@@ -62,12 +62,6 @@ dependencies:
     dependencies:
       - project: kiegroup/droolsjbpm-integration
 
-  - project: kiegroup/droolsjbpm-tools
-    dependencies:
-      - project: kiegroup/jbpm
-      - project: kiegroup/drools
-      - project: kiegroup/kie-soup
-
   - project: kiegroup/kie-uberfire-extensions
     dependencies:
       - project: kiegroup/appformer

--- a/script/repository-list.txt
+++ b/script/repository-list.txt
@@ -10,7 +10,6 @@ lienzo-tests
 appformer
 droolsjbpm-integration
 openshift-drools-hacep
-droolsjbpm-tools
 kie-uberfire-extensions
 kie-wb-playground
 kie-wb-common


### PR DESCRIPTION
**Thank you for submitting this pull request**

**JIRA**: _(please edit the JIRA link if it exists)_ 

[AF-2675](https://issues.redhat.com/browse/AF-2675)

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1520
* https://github.com/kiegroup/kie-jenkins-scripts/pull/853

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
