### PR TITLE
removed sonarcloud command from properties files

### DIFF
--- a/.ci/pullrequest.properties
+++ b/.ci/pullrequest.properties
@@ -5,7 +5,6 @@ goals.appformer.upstream=-e clean install -DskipTests -Dgwt.compiler.skip=true -
 goals.drools.upstream=-e clean install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true
 goals.kie-wb-common.upstream=-e clean install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true
 goals.optaplanner.upstream=-e clean install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true
-goals.default.sonarcloud=-nsu generate-resources -Psonarcloud-analysis
 goals.kie-docs.current=clean install
 goals.optaplanner.current=-e clean install -nsu -Prun-code-coverage,wildfly -Dfull  -Dintegration-tests=true -Dmaven.test.failure.ignore=true
 goals.kie-wb-common.current=-e -nsu -Dfull clean install -Prun-code-coverage -Pwildfly -Dcontainer=wildfly -Dcontainer.profile=wildfly -Dintegration-tests=true -Dmaven.test.failure.ignore=true -Dwebdriver.firefox.bin=/opt/tools/firefox-60esr/firefox-bin


### PR DESCRIPTION
sonarcloud command is directly in Jenkinsfile

https://issues.redhat.com/browse/BXMSPROD-1086

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
