### PR TITLE
(GSS) [7.44.x] [RHPAM-3219] No Model definition in KIE Server Swagger API 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -330,6 +330,7 @@
     <version.com.wordnik.swagger>1.3.10</version.com.wordnik.swagger>
     <version.io.swagger>1.5.20</version.io.swagger>
     <version.io.swagger.core.v3>2.0.6</version.io.swagger.core.v3>
+    <version.io.swagger.swagger-parser>1.0.36</version.io.swagger.swagger-parser>
     <version.org.jboss.byteman>3.0.1</version.org.jboss.byteman>
     <version.org.roboguice>3.0.1</version.org.roboguice>
     <version.org.robolectric>3.1.2</version.org.robolectric>
@@ -4855,6 +4856,13 @@
         <groupId>io.swagger.core.v3</groupId>
         <artifactId>swagger-annotations</artifactId>
         <version>${version.io.swagger.core.v3}</version>
+      </dependency>
+      
+      <!-- swagger parser -->
+      <dependency>
+        <groupId>io.swagger</groupId>
+        <artifactId>swagger-parser</artifactId>
+        <version>${version.io.swagger.swagger-parser}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
**JIRA** [JBPM-9410](https://issues.redhat.com/browse/JBPM-9410)

**Merge with** [JBPM:1174](https://github.com/kiegroup/droolsjbpm-integration/pull/2274)

Added swagger parser dependency needed for testing swagger.json composition