### PR TITLE
getProjectTriggering job error solved

### DIFF
--- a/.ci/compilation.stages
+++ b/.ci/compilation.stages
@@ -8,8 +8,7 @@ def call(def propertiesFolderPath) {
             def file = readFile REPOSITORY_LIST_FILE
             def projectCollection = file.readLines()
             projectCollection.removeAll(['kie-jpmml-integration','kie-docs'])
-            def gitURL = env.ghprbAuthorRepoGitUrl ?: env.GIT_URL
-            def project = util.getProjectGroupName(util.getProject(gitURL))[1]
+            def project = util.getProjectTriggeringJob()[1]
             compile.build(projectCollection, project, "${SETTINGS_XML_ID}", "${PROPERTIES_FILE_PATH}")
         }
     }

--- a/.ci/fullDownstream.stages
+++ b/.ci/fullDownstream.stages
@@ -7,8 +7,7 @@ def call(def propertiesFolderPath) {
             println "Reading file ${REPOSITORY_LIST_FILE}"
             def file = readFile REPOSITORY_LIST_FILE
             def projectCollection = file.readLines()
-            def gitURL = env.ghprbAuthorRepoGitUrl ?: env.GIT_URL
-            def project = util.getProjectGroupName(util.getProject(gitURL))[1]
+            def project = util.getProjectTriggeringJob()[1]
             projectCollection.removeAll(['droolsjbpm-tools', 'kie-docs'])
             compile.build(projectCollection, project, "${SETTINGS_XML_ID}", "${PROPERTIES_FILE_PATH}")
         }

--- a/.ci/pullrequest.stages
+++ b/.ci/pullrequest.stages
@@ -7,8 +7,7 @@ def call(def propertiesFolderPath) {
             println "Reading file ${REPOSITORY_LIST_FILE}"
             def file = readFile REPOSITORY_LIST_FILE
             def projectCollection = file.readLines()
-            def gitURL = env.ghprbAuthorRepoGitUrl ?: env.GIT_URL
-            def project = util.getProjectGroupName(util.getProject(gitURL))[1]
+            def project = util.getProjectTriggeringJob()[1]
             if (project != "kie-docs") {
                 pullrequest.build(projectCollection, project, "${SETTINGS_XML_ID}", "${PROPERTIES_FILE_PATH}", "")
             } else {

--- a/.ci/upstream.stages
+++ b/.ci/upstream.stages
@@ -7,8 +7,7 @@ def call(def propertiesFolderPath) {
             def file = readFile REPOSITORY_LIST_FILE
             def projectCollection = file.readLines()
             projectCollection.removeAll(['kie-jpmml-integration'])
-            def gitURL = env.ghprbAuthorRepoGitUrl ?: env.GIT_URL
-            def project = util.getProjectGroupName(util.getProject(gitURL))[1]
+            def project = util.getProjectTriggeringJob()[1]
 
             treebuild.upstreamBuild(projectCollection, project, "${SETTINGS_XML_ID}", 'clean install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true')
         }

--- a/.github/workflows/generate_files.yml
+++ b/.github/workflows/generate_files.yml
@@ -13,7 +13,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
+          token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Image Generation
         uses: kiegroup/build-chain-files-generator@main
         with:
@@ -38,7 +40,7 @@ jobs:
         run: |
           git config user.name "kiegroup"
           git config user.email "kiegroup@redhat.com"
-          git add ./doc/project-dependencies-hierarchy.png ./script/repository-list.txt
+          git add ./docs/project-dependencies-hierarchy.png ./script/repository-list.txt
           git commit -m "[Build Chain Generate Files] project hierarchy files updated"
           git push
       - name: Archive artifacts

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -70,8 +70,7 @@ pipeline {
             steps {
                 script {
                     if(isPR()) {
-                        def gitURL = env.ghprbAuthorRepoGitUrl ?: env.GIT_URL
-                        def project = util.getProjectGroupName(util.getProject(gitURL))[1]
+                        def project = util.getProjectTriggeringJob()[1]
                         if(["optaplanner", "drools", "appformer", "jbpm", "drools-wb", "kie-soup", "droolsjbpm-integration", "kie-wb-common", "openshift-drools-hacep", "optaweb-employee-rostering", "optaweb-vehicle-routing"].contains(project))
                         {
                             dir("${env.WORKSPACE}") {

--- a/Jenkinsfile.buildchain
+++ b/Jenkinsfile.buildchain
@@ -57,8 +57,7 @@ pipeline {
             steps {
                 script {
                     if(isPR()) {
-                        def gitURL = env.ghprbAuthorRepoGitUrl ?: env.GIT_URL
-                        def project = util.getProjectGroupName(util.getProject(gitURL))[1]
+                        def project = util.getProjectTriggeringJob()[1]
                         if(["optaplanner", "drools", "appformer", "jbpm", "drools-wb", "kie-soup", "droolsjbpm-integration", "kie-wb-common", "openshift-drools-hacep", "optaweb-employee-rostering", "optaweb-vehicle-routing"].contains(project))
                         {
                             dir("${env.WORKSPACE}") {


### PR DESCRIPTION
**Thank you for submitting this pull request**
I would have to find alternatives to "Build Chain Generate Files / File Generation" from a forked project. Meanwhile please consider the solution for the getProjectTriggering problem and I will treat "Build Chain Generate Files / File Generation" in a different one.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
