### PR TITLE
increased timeout when uploading to Nexus and added option to not dro…

### DIFF
--- a/script/release/06_uploadBinariesToNexus.sh
+++ b/script/release/06_uploadBinariesToNexus.sh
@@ -17,4 +17,4 @@ deployDir=$WORKSPACE/community-deploy-dir
 
 cd $deployDir
 # upload the content to remote staging repo on Nexus
-mvn -B -e -s $SETTINGS_XML_FILE -Dkie.maven.settings.custom=$SETTINGS_XML_FILE org.sonatype.plugins:nexus-staging-maven-plugin:1.6.5:deploy-staged-repository -DnexusUrl=https://repository.jboss.org/nexus -DserverId=jboss-releases-repository -DrepositoryDirectory=$deployDir -DstagingProfileId=$stagingRep -DstagingDescription="kie-$kieVersion" -DkeepStagingRepositoryOnCloseRuleFailure=true -DstagingProgressTimeoutMinutes=10
+mvn -B -e -s $SETTINGS_XML_FILE -Dkie.maven.settings.custom=$SETTINGS_XML_FILE org.sonatype.plugins:nexus-staging-maven-plugin:1.6.5:deploy-staged-repository -DnexusUrl=https://repository.jboss.org/nexus -DserverId=jboss-releases-repository -DrepositoryDirectory=$deployDir -DstagingProfileId=$stagingRep -DstagingDescription="kie-$kieVersion" -DkeepStagingRepositoryOnCloseRuleFailure=true -DkeepStagingRepositoryOnFailure=true -DstagingProgressTimeoutMinutes=120


### PR DESCRIPTION
- increased timeout when uploading binaries to Nexus
- added -DkeepStagingRepositoryOnFailure=true to the upload srcipt so when there is a failure during the upload the staging repository will not be dropped automatically [to better see what happens]

The community pipeline breaks very often when uploading binaries to Nexus and we hope with these changes we can see more.