### PR TITLE
wb-common should not depend on wb-playground

### DIFF
--- a/.ci/project-dependencies.yaml
+++ b/.ci/project-dependencies.yaml
@@ -74,7 +74,6 @@ dependencies:
   - project: kiegroup/kie-wb-common
     dependencies:
       - project: kiegroup/lienzo-core
-      - project: kiegroup/kie-wb-playground
       - project: kiegroup/droolsjbpm-integration
 
   - project: kiegroup/drools-wb


### PR DESCRIPTION
Hi @mbiarnes, @mareknovotny,  @Ginxo I removed kie-wb-playground dependency from kie-wb-common because this dependency don't make sense to me and make addition instabilities. Do I miss something there? Is kie-wb-common really depends on kie-wb-playground?

I executed `mvn dependency:tree | grep "kie-wb-pla"` on `kie-wb-common` root directory and nothing was found, so I assume it should be safe to delete kie-wb-playground.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
