### PR TITLE
generate files flow

### DIFF
--- a/.github/workflows/generate_files.yml
+++ b/.github/workflows/generate_files.yml
@@ -1,7 +1,9 @@
 name: Build Chain Generate Files
 
 on:
-  pull_request:
+  push:
+    branches:
+      - master
     paths:
       - '.ci/**'
 
@@ -11,9 +13,6 @@ jobs:
     name: File Generation
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.ref }}
       - name: Image Generation
         uses: kiegroup/build-chain-files-generator@main
         with:
@@ -33,13 +32,8 @@ jobs:
           file-type: repository-list
           output-file-path: ./script/branched-7-repository-list.txt
           include: "@master:7.x"
-      - name: Push Changes
-        run: |
-          git config user.name "kiegroup"
-          git config user.email "kiegroup@redhat.com"
-          git add ./doc/project-dependencies-hierarchy.png ./script/repository-list.txt
-          git commit -m "[Build Chain Generate Files] project hierarchy files updated"
-          git push
+      - name: Add Changes
+        run: git add ./docs/project-dependencies-hierarchy.png ./script/repository-list.txt ./script/branched-7-repository-list.txt
       - name: Archive artifacts
         uses: actions/upload-artifact@v2
         with:
@@ -47,4 +41,29 @@ jobs:
           path: |
             **/project-dependencies-hierarchy.png
             **/repository-list.txt          
-            **/branched-7-repository-list.txt          
+            **/branched-7-repository-list.txt           
+      - name: Set branch name
+        run: echo "BRANCH_NAME_FLOW=generate_files_$(date +'%Y%m%dT%H%M%S')" >> $GITHUB_ENV          
+      - name: Create Pull Request
+        id: cpr
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: Update build chain files
+          committer: GitHub <noreply@github.com>
+          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+          signoff: false
+          branch: ${{ env.BRANCH_NAME_FLOW }}
+          delete-branch: true
+          title: '[Build Chain] Update build chain and repository-list files.'
+          body: |
+            Update report
+            - ./docs/project-dependencies-hierarchy.png
+            - ./script/repository-list.txt
+            - ./script/branched-7-repository-list.txt
+          reviewers: mbiarnes,ginxo,mareknovotny
+          draft: false
+      - name: Check outputs
+        run: |
+          echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
+          echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"


### PR DESCRIPTION
There's no way to modify PR adding files generated by the flow due to security problems. So, the only way I've found is to trigger the flow on a `push` event and create a new PR to modify image and repository-list files.
You can check a automatically generated PR by this flow 
https://github.com/Ginxo/droolsjbpm-build-bootstrap/pull/32

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
