### PR TITLE
[BXMSPROD-1037] - Upgrade jackson-databind to 2.11.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,9 +73,9 @@
     </version.com.ahome-it.lienzo.tooling.nativetools>
     <version.com.ahome-it.lienzo.tooling.common>1.0.190-RELEASE</version.com.ahome-it.lienzo.tooling.common>
     <version.com.allen-sauer.gwt.dnd>3.3.3</version.com.allen-sauer.gwt.dnd>
-    <version.com.fasterxml.jackson>2.10.4</version.com.fasterxml.jackson>
-    <version.com.fasterxml.jackson.databind>2.10.4</version.com.fasterxml.jackson.databind>
-    <version.com.fasterxml.jackson.annotations>2.9.10</version.com.fasterxml.jackson.annotations>
+    <version.com.fasterxml.jackson>2.11.0</version.com.fasterxml.jackson>
+    <version.com.fasterxml.jackson.databind>2.11.0</version.com.fasterxml.jackson.databind>
+    <version.com.fasterxml.jackson.annotations>2.11.0</version.com.fasterxml.jackson.annotations>
     <version.com.google.code.gson>2.8.6</version.com.google.code.gson>
     <version.com.google.guava>25.0-jre</version.com.google.guava>
     <version.com.google.inject.guice>4.0</version.com.google.inject.guice>
@@ -4084,7 +4084,7 @@
         <artifactId>mockito-core</artifactId>
         <version>${version.org.mockito}</version>
       </dependency>
-	  
+
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-inline</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -328,7 +328,7 @@
     <version.org.picketlink>2.6.0.Final</version.org.picketlink>
     <version.com.unboundid>3.2.0</version.com.unboundid>
     <version.com.wordnik.swagger>1.3.10</version.com.wordnik.swagger>
-    <version.io.swagger>1.5.20</version.io.swagger>
+    <version.io.swagger>1.6.2</version.io.swagger>
     <version.io.swagger.core.v3>2.0.6</version.io.swagger.core.v3>
     <version.io.swagger.swagger-parser>1.0.36</version.io.swagger.swagger-parser>
     <version.org.jboss.byteman>4.0.13</version.org.jboss.byteman>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
     <version.com.allen-sauer.gwt.dnd>3.3.3</version.com.allen-sauer.gwt.dnd>
     <version.com.fasterxml.jackson>2.11.0</version.com.fasterxml.jackson>
     <version.com.fasterxml.jackson.databind>2.11.0</version.com.fasterxml.jackson.databind>
-    <version.com.fasterxml.jackson.annotations>2.11.0</version.com.fasterxml.jackson.annotations>
+    <version.com.fasterxml.jackson.annotations>2.9.10</version.com.fasterxml.jackson.annotations>
     <version.com.google.code.gson>2.8.6</version.com.google.code.gson>
     <version.com.google.guava>25.0-jre</version.com.google.guava>
     <version.com.google.inject.guice>4.0</version.com.google.inject.guice>
@@ -2441,7 +2441,7 @@
         <artifactId>nv-i18n</artifactId>
         <version>${version.com.neovisionaries}</version>
       </dependency>
-      
+
       <dependency>
         <groupId>com.networknt</groupId>
         <artifactId>json-schema-validator</artifactId>
@@ -2505,7 +2505,7 @@
         <artifactId>springfox-swagger-ui</artifactId>
         <version>${version.io.springfox}</version>
       </dependency>
-      
+
       <dependency>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-open-api-core</artifactId>
@@ -3400,7 +3400,7 @@
         <artifactId>batik-codec</artifactId>
         <version>${version.org.apache.xmlgraphics.batik}</version>
       </dependency>
-      
+
       <dependency>
         <groupId>org.asciidoctor</groupId>
         <artifactId>asciidoctorj</artifactId>
@@ -4876,14 +4876,14 @@
         <artifactId>swagger-models</artifactId>
         <version>${version.io.swagger}</version>
       </dependency>
-      
+
       <!-- OAS v3 -->
       <dependency>
         <groupId>io.swagger.core.v3</groupId>
         <artifactId>swagger-annotations</artifactId>
         <version>${version.io.swagger.core.v3}</version>
       </dependency>
-      
+
       <!-- swagger parser -->
       <dependency>
         <groupId>io.swagger</groupId>
@@ -5362,7 +5362,7 @@
         </exclusions>
         <scope>test</scope>
       </dependency>
-      
+
       <!-- Used by jgit -->
       <dependency>
         <groupId>org.bouncycastle</groupId>


### PR DESCRIPTION
**Thank you for submitting this pull request**

**JIRA**:

https://issues.redhat.com/browse/BXMSPROD-1037

**referenced Pull Requests**:

* https://github.com/kiegroup/appformer/pull/1086
* https://github.com/kiegroup/droolsjbpm-integration/pull/2340
* https://github.com/kiegroup/jbpm/pull/1820
* https://github.com/kiegroup/kie-wb-common/pull/3542
* https://github.com/kiegroup/drools-wb/pull/1456
* https://github.com/kiegroup/jbpm-designer/pull/897
* https://github.com/kiegroup/jbpm-work-items/pull/170
* https://github.com/kiegroup/jbpm-wb/pull/1476
* https://github.com/kiegroup/optaplanner-wb/pull/387
* https://github.com/kiegroup/kie-wb-distributions/pull/1082

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
