### PR TITLE
[7.48.x] JBPM-9542: Remove issue-keeper tool

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -308,7 +308,6 @@
     <version.com.google.testing.compile>0.11</version.com.google.testing.compile>
     <version.jakarta-regexp>1.4</version.jakarta-regexp>
     <version.jakarta.json.bind>1.0.2</version.jakarta.json.bind>
-    <version.link.bek.tools.issue-keeper-junit>4.11.1</version.link.bek.tools.issue-keeper-junit>
     <version.org.antlr4>4.8</version.org.antlr4>
     <version.org.apache.cxf>3.2.14</version.org.apache.cxf>
     <version.org.apache.camel>2.24.0</version.org.apache.camel>
@@ -4623,12 +4622,6 @@
         <groupId>javax.xml.stream</groupId>
         <artifactId>stax-api</artifactId>
         <version>${version.javax.xml.stream.stax}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>link.bek.tools</groupId>
-        <artifactId>issue-keeper-junit</artifactId>
-        <version>${version.link.bek.tools.issue-keeper-junit}</version>
       </dependency>
 
       <!-- dependency of org.apache.lucene:lucene-sandbox -->


### PR DESCRIPTION
#1563 cherry-pick

Due to recent jira authentication changes we decided to stop using issue-keeper tool for preventing test method run. It was replaced by simple '@Ignore' junit annotations.

For more details see:
- https://issues.redhat.com/browse/JBPM-9542
- https://github.com/ibek/issue-keeper

**Thank you for submitting this pull request**

**JIRA**: _(please edit the JIRA link if it exists)_ 

[link](https://www.example.com)

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* https://github.com/kiegroup/kie-wb-distributions/pull/1081
* https://github.com/kiegroup/jbpm/pull/1831
<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
