### PR TITLE
Fixing broken upstream repository deps for kie-wb-common

### DIFF
--- a/.ci/project-dependencies.yaml
+++ b/.ci/project-dependencies.yaml
@@ -74,6 +74,8 @@ dependencies:
   - project: kiegroup/kie-wb-common
     dependencies:
       - project: kiegroup/lienzo-core
+      - project: kiegroup/appformer
+      - project: kiegroup/kie-uberfire-extensions
       - project: kiegroup/kie-wb-playground
       - project: kiegroup/droolsjbpm-integration
 


### PR DESCRIPTION
There is a cross repo PR https://github.com/kiegroup/appformer/pull/987  from @jomarko which fails as Appformer PR adds new classes and kie-wb-common repo GA CI fails on missing them

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
