### PR TITLE
fixed removal commands in shell scripts

### DIFF
--- a/script/release/10a_drools_upload_filemgmt.sh
+++ b/script/release/10a_drools_upload_filemgmt.sh
@@ -76,5 +76,5 @@ if [[ "${kieVersion}" == *Final* ]]; then
 fi
 
 # remove files and directories for uploading drools
-rm upload_*
+rm -rf upload_*
 rm -rf filemgmt_links

--- a/script/release/10b_jbpm_upload_filemgmt.sh
+++ b/script/release/10b_jbpm_upload_filemgmt.sh
@@ -91,5 +91,5 @@ if [[ "${kieVersion}" == *Final* ]]; then
 fi
 
 # remove files and directories for uploading drools
-rm upload_*
+rm -rf upload_*
 rm -rf filemgmt_links

--- a/script/release/10c_optaplanner_upload_filemgmt.sh
+++ b/script/release/10c_optaplanner_upload_filemgmt.sh
@@ -61,6 +61,6 @@ scp -r -i $1 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $upload
 
 
 # remove files and directories for uploading optaplanner
-rm upload_*
+rm -rf upload_*
 
 


### PR DESCRIPTION
**Thank you for submitting this pull request**
The simple `rm` command in shell scripts had to be replaced by `rm -rf` so the removal could be executed and the shell script doesn't exit premature and the whole pipeline fails. 

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
