### PR TITLE
Jenkinsfile.buildchain tools replaced by nodejs

### DIFF
--- a/Jenkinsfile.buildchain
+++ b/Jenkinsfile.buildchain
@@ -13,8 +13,7 @@ pipeline {
         label agentLabel
     }
     tools {
-        maven 'kie-maven-3.6.3'
-        jdk 'kie-jdk1.8'
+        nodejs 'nodejs-12.16.3'
     }
     options {
         timestamps ()


### PR DESCRIPTION
**Thank you for submitting this pull request**


<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
