### PR TITLE
Upload jbpm binaries

### DIFF
--- a/script/release/10a_drools_upload_filemgmt.sh
+++ b/script/release/10a_drools_upload_filemgmt.sh
@@ -66,5 +66,6 @@ if [[ "${kieVersion}" == *Final* ]]; then
 fi
 
 # remove files and directories for uploading drools
+cd ..
 rm -rf upload_*
 rm -rf filemgmt_links

--- a/script/release/10b_jbpm_upload_filemgmt.sh
+++ b/script/release/10b_jbpm_upload_filemgmt.sh
@@ -66,6 +66,7 @@ if [[ "${kieVersion}" == *Final* ]]; then
     rsync -e "ssh -i $1 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" --protocol=28 -a latestFinal $jbpmHtdocs
 fi
 
-# remove files and directories for uploading drools
+# remove files and directories for uploading jbpm
+cd ..
 rm -rf upload_*
 rm -rf filemgmt_links

--- a/script/release/10b_jbpm_upload_filemgmt.sh
+++ b/script/release/10b_jbpm_upload_filemgmt.sh
@@ -34,24 +34,9 @@ scp -i $1 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $uploadDir
 scp -i $1 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $uploadDir/jbpm-$kieVersion-examples.zip $jbpmHtdocs/$kieVersion
 scp -i $1 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $uploadDir/jbpm-server-$kieVersion-dist.zip $jbpmHtdocs/$kieVersion
 
-# uploads jbpm -installers them to filemgt.jboss.org
-uploadInstaller(){
-        # upload installers to filemgmt.jboss.org
-        scp -i $1 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null jbpm-installer-$kieVersion.zip $jbpmHtdocs/$kieVersion
-}
-
-uploadAllInstaller(){
-        # upload installers to filemgmt.jboss.org
-        scp -i $1 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null jbpm-installer-$kieVersion.zip $jbpmHtdocs/$kieVersion
-        # upload installers to filemgmt.jboss.org
-        scp -i $1 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null jbpm-installer-full-$kieVersion.zip $jbpmHtdocs/$kieVersion
-}
-
-if [[ $kieVersion == *"Final"* ]] ;then
-        uploadAllInstaller
-else
-        uploadInstaller
-fi
+# uploads jbpm -installers to filemgt.jboss.org
+scp -i $1 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null jbpm-installer-$kieVersion.zip $jbpmHtdocs/$kieVersion
+scp -i $1 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null jbpm-installer-full-$kieVersion.zip $jbpmHtdocs/$kieVersion
 
 # docs
 scp -r -i $1 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $uploadDir/jbpm-docs/* $jbpmDocs/$kieVersion/jbpm-docs


### PR DESCRIPTION
**Thank you for submitting this pull request**

- since there is not any more the difference between a latest and latestFinal release (we only have Final releases) the condition could be erased. In a release both files (jbpm-installer-$kieVersion.zip & jbpm-installer-full-$kieVersion.zip) have to be uploaded.
- files that should be removed at end of the upload weren't removed because simply the script was in the wrong directory

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
