### PR TITLE
BAQE-1696 - Change revapi to check against 7.48.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -437,7 +437,7 @@
 
 
     <!-- Latest release to be used by api-compatibility-check to check backwards compatibility of the Kie API. -->
-    <revapi.oldKieVersion>7.44.0.Final</revapi.oldKieVersion>
+    <revapi.oldKieVersion>7.48.0.Final</revapi.oldKieVersion>
     <revapi.newKieVersion>${project.version}</revapi.newKieVersion>
 
     <version.org.jboss.spec.javax.websocket>1.1.3.Final</version.org.jboss.spec.javax.websocket>


### PR DESCRIPTION
**JIRA:** [BAQE-1696](https://issues.redhat.com/browse/BAQE-1696)

PR set:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1585
* https://github.com/kiegroup/appformer/pull/1102
* https://github.com/kiegroup/droolsjbpm-knowledge/pull/501
* https://github.com/kiegroup/drools/pull/3376
* https://github.com/kiegroup/jbpm/pull/1862
* https://github.com/kiegroup/droolsjbpm-integration/pull/2394
* https://github.com/kiegroup/optaplanner/pull/1161

