### PR TITLE
DROOLS-6021 : Migrate standalone Business Central from Thorntail to EAP Bootable Jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -434,7 +434,13 @@
     </jboss.releases.repo.url>
     <jboss.snapshots.repo.url>https://repository.jboss.org/nexus/content/repositories/snapshots/
     </jboss.snapshots.repo.url>
-
+    
+    <version.server.bom>7.3.4.GA</version.server.bom>
+    <version.microprofile.bom>2.0.0.GA</version.microprofile.bom>
+    <version.server.bootable-jar>2.0.0.GA-redhat-00002</version.server.bootable-jar>
+    <version.wildfly-jar.maven.plugin>2.0.2.Final-redhat-00001</version.wildfly-jar.maven.plugin>
+    <version.jkube.maven.plugin>1.0.1</version.jkube.maven.plugin>
+    <jkube.generator.from>registry.redhat.io/ubi8/openjdk-11:latest</jkube.generator.from>
 
     <!-- Latest release to be used by api-compatibility-check to check backwards compatibility of the Kie API. -->
     <revapi.oldKieVersion>7.44.0.Final</revapi.oldKieVersion>


### PR DESCRIPTION

**JIRA**:  

[DROOLS-6021](https://issues.redhat.com/browse/DROOLS-6021)

**referenced Pull Requests**: 

* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1588
* https://github.com/kiegroup/kie-wb-distributions/pull/1086

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
