### PR TITLE
[DROOLS-6036] move common utility/shared classes outside drools-core

### DIFF
--- a/drools-bom/pom.xml
+++ b/drools-bom/pom.xml
@@ -125,6 +125,24 @@
       </dependency>
       <dependency>
         <groupId>org.drools</groupId>
+        <artifactId>drools-utils</artifactId>
+        <version>${version.org.kie}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.drools</groupId>
+        <artifactId>drools-utils</artifactId>
+        <version>${version.org.kie}</version>
+        <classifier>sources</classifier>
+      </dependency>
+      <dependency>
+        <groupId>org.drools</groupId>
+        <artifactId>drools-utils</artifactId>
+        <version>${version.org.kie}</version>
+        <type>test-jar</type>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.drools</groupId>
         <artifactId>drools-core</artifactId>
         <version>${version.org.kie}</version>
       </dependency>


### PR DESCRIPTION
**JIRA**: https://issues.redhat.com/browse/DROOLS-6036

