### PR TITLE
[JBPM-9355] - Stabilize some jBPM integration tests by upgrading TJWSEmbeddedJaxrsServer embedded server

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3908,6 +3908,12 @@
         <artifactId>tjws</artifactId>
         <version>${version.org.jboss.resteasy}</version>
       </dependency>
+      <dependency>
+        <groupId>org.jboss.resteasy</groupId>
+        <artifactId>resteasy-undertow</artifactId>
+        <version>${version.org.jboss.resteasy}</version>
+      </dependency>
+
 
       <dependency>
         <groupId>org.jboss.remoting</groupId>


### PR DESCRIPTION
**[JBPM-9355](https://issues.redhat.com/browse/JBPM-9355)**: Stabilize some jBPM integration tests by upgrading TJWSEmbeddedJaxrsServer embedded server