### PR TITLE
new stages for measuring disk space before and after build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,6 +35,13 @@ pipeline {
                 }
             }
         }
+        stage('check space before build') {
+            steps {
+                script{
+                    util.spaceLeft()
+                }
+            }
+        }
         stage('Build projects') {
             steps {
                 script {
@@ -82,6 +89,13 @@ pipeline {
                     } else {
                         println "[INFO] No sonar analysis execution."
                     }
+                }
+            }
+        }
+        stage('check space after build') {
+            steps {
+                script{
+                    util.spaceLeft()
                 }
             }
         }

--- a/Jenkinsfile.buildchain
+++ b/Jenkinsfile.buildchain
@@ -33,6 +33,13 @@ pipeline {
                 }
             }
         }
+        stage('check space before build') {
+            steps {
+                script{
+                    util.spaceLeft()
+                }
+            }
+        }
         stage('Build projects') {
             steps {
                 script {
@@ -79,6 +86,13 @@ pipeline {
                     } else {
                         println "[INFO] No sonar analysis execution."
                     }
+                }
+            }
+        }
+        stage('check space after build') {
+            steps {
+                script{
+                    util.spaceLeft()
                 }
             }
         }


### PR DESCRIPTION
**Thank you for submitting this pull request**

This calls a method to simply read the disk space before and after each PR.
Done to better understand why we encounter so much "no space left on device" errors.

https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1597
https://github.com/kiegroup/jenkins-pipeline-shared-libraries/pull/145

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
