### PR TITLE
removed droolsjbpm-tools

### DIFF
--- a/.ci/project-dependencies.yaml
+++ b/.ci/project-dependencies.yaml
@@ -149,9 +149,3 @@ dependencies:
       - project: kiegroup/kie-uberfire-extensions
       - project: kiegroup/optaplanner-wb
 
-  - project: kiegroup/droolsjbpm-tools
-    dependencies:
-      - project: kiegroup/droolsjbpm-build-bootstrap
-      - project: kiegroup/jbpm
-      - project: kiegroup/drools
-      - project: kiegroup/kie-soup


### PR DESCRIPTION
**Thank you for submitting this pull request**

The removal of `droolsjbpm-tools` in this file should determine a new repository-list.txt without it.
Looking in the kie-jenkins-scripts (PRs, FDBs and CDBs `droolsjbpm-tools` is not present).
 

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
