### PR TITLE
[7.52.x][BXMSPROD-1273] backport of Xstream upgrade to 1.4.16

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
     <version.com.neovisionaries>1.27</version.com.neovisionaries>
     <version.com.networknt.json-schema-validator>1.0.43</version.com.networknt.json-schema-validator>
     <version.com.sun.xml.bind>2.3.0</version.com.sun.xml.bind>
-    <version.com.thoughtworks.xstream>1.4.15</version.com.thoughtworks.xstream>
+    <version.com.thoughtworks.xstream>1.4.16</version.com.thoughtworks.xstream>
     <version.de.benediktmeurer.gwt-slf4j>0.0.2</version.de.benediktmeurer.gwt-slf4j>
     <version.org.dom4j>2.1.3</version.org.dom4j>
     <version.io.springfox>2.9.2</version.io.springfox>


### PR DESCRIPTION
https://issues.redhat.com/browse/BXMSPROD-1273

Backporting of https://github.com/kiegroup/droolsjbpm-build-bootstrap/commit/0f2c8c33a8111f50f96c522d0fc3c1a964c1f613

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
