### PR TITLE
[BXMSPROD-1285] - Upgraded version of maven-core to overcome the validation failures

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
     <version.org.apache.httpcomponents.httpcore>4.4.6</version.org.apache.httpcomponents.httpcore>
     <version.org.apache.karaf>2.4.0</version.org.apache.karaf>
     <version.org.apache.lucene>6.6.1</version.org.apache.lucene>
-    <version.org.apache.maven>3.3.9</version.org.apache.maven>
+    <version.org.apache.maven>3.6.3</version.org.apache.maven>
     <version.org.apache.maven.utils>3.2.1</version.org.apache.maven.utils>
     <version.org.apache.maven.archiver>3.3.0</version.org.apache.maven.archiver>
     <version.org.apache.maven.plugin-tools>3.4</version.org.apache.maven.plugin-tools>
@@ -2502,7 +2502,7 @@
         <artifactId>nv-i18n</artifactId>
         <version>${version.com.neovisionaries}</version>
       </dependency>
-      
+
       <dependency>
         <groupId>com.networknt</groupId>
         <artifactId>json-schema-validator</artifactId>
@@ -2572,7 +2572,7 @@
         <artifactId>springfox-swagger-ui</artifactId>
         <version>${version.io.springfox}</version>
       </dependency>
-      
+
       <dependency>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-open-api-core</artifactId>
@@ -3505,7 +3505,7 @@
         <artifactId>batik-codec</artifactId>
         <version>${version.org.apache.xmlgraphics.batik}</version>
       </dependency>
-      
+
       <dependency>
         <groupId>org.asciidoctor</groupId>
         <artifactId>asciidoctorj</artifactId>
@@ -4195,7 +4195,7 @@
         <artifactId>mockito-core</artifactId>
         <version>${version.org.mockito}</version>
       </dependency>
-	  
+
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-inline</artifactId>
@@ -4987,7 +4987,7 @@
         <artifactId>swagger-models</artifactId>
         <version>${version.io.swagger}</version>
       </dependency>
-      
+
       <!-- OAS v3 -->
       <dependency>
         <groupId>io.swagger.core.v3</groupId>
@@ -5000,7 +5000,7 @@
         <version>${version.io.swagger.parser.v3}</version>
         <scope>test</scope>
         <exclusions><!-- banned for kie-server tests: -->
-          <exclusion> 
+          <exclusion>
             <groupId>javax.mail</groupId>
             <artifactId>mailapi</artifactId>
           </exclusion>
@@ -5010,21 +5010,21 @@
           </exclusion>
         </exclusions>
       </dependency>
-      
+
       <!-- swagger parser -->
       <dependency>
         <groupId>io.swagger</groupId>
         <artifactId>swagger-parser</artifactId>
         <version>${version.io.swagger.swagger-parser}</version>
       </dependency>
-      
+
       <dependency>
         <groupId>io.rest-assured</groupId>
         <artifactId>rest-assured</artifactId>
         <version>${version.io.rest-assured}</version>
         <scope>test</scope>
         <exclusions><!-- banned for kie-server tests: -->
-          <exclusion> 
+          <exclusion>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
           </exclusion>
@@ -5510,7 +5510,7 @@
         </exclusions>
         <scope>test</scope>
       </dependency>
-      
+
       <!-- Used by jgit -->
       <dependency>
         <groupId>org.bouncycastle</groupId>


### PR DESCRIPTION
The MRRC validation failures are caused, by the com.google.inject:guice:4.0, on which maven-core 3.3.9 depends.
Upgrading for the newer maven-core version.

**Thank you for submitting this pull request**

**JIRA**:

[BXMSPROD-1285](https://issues.redhat.com/browse/BXMSPROD-1285)

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
