### PR TITLE
KOGITO-5016: Remove Kogito-related modules from v7 stream

### DIFF
--- a/drools-bom/pom.xml
+++ b/drools-bom/pom.xml
@@ -913,63 +913,6 @@
       </dependency>
       <dependency>
         <groupId>org.drools</groupId>
-        <artifactId>drools-wb-scenario-simulation-editor-kogito-marshaller</artifactId>
-        <version>${version.org.kie}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.drools</groupId>
-        <artifactId>drools-wb-scenario-simulation-editor-kogito-marshaller</artifactId>
-        <version>${version.org.kie}</version>
-        <classifier>sources</classifier>
-      </dependency>
-      <dependency>
-        <groupId>org.drools</groupId>
-        <artifactId>drools-wb-scenario-simulation-editor-kogito-client</artifactId>
-        <version>${version.org.kie}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.drools</groupId>
-        <artifactId>drools-wb-scenario-simulation-editor-kogito-client</artifactId>
-        <version>${version.org.kie}</version>
-        <classifier>sources</classifier>
-      </dependency>
-      <dependency>
-        <groupId>org.drools</groupId>
-        <artifactId>drools-wb-scenario-simulation-editor-kogito-webapp-common</artifactId>
-        <version>${version.org.kie}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.drools</groupId>
-        <artifactId>drools-wb-scenario-simulation-editor-kogito-webapp-common</artifactId>
-        <version>${version.org.kie}</version>
-        <classifier>sources</classifier>
-      </dependency>
-      <dependency>
-        <groupId>org.drools</groupId>
-        <artifactId>drools-wb-scenario-simulation-editor-kogito-runtime</artifactId>
-        <type>war</type>
-        <version>${version.org.kie}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.drools</groupId>
-        <artifactId>drools-wb-scenario-simulation-editor-kogito-runtime</artifactId>
-        <version>${version.org.kie}</version>
-        <classifier>sources</classifier>
-      </dependency>
-      <dependency>
-        <groupId>org.drools</groupId>
-        <artifactId>drools-wb-scenario-simulation-editor-kogito-testing</artifactId>
-        <type>war</type>
-        <version>${version.org.kie}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.drools</groupId>
-        <artifactId>drools-wb-scenario-simulation-editor-kogito-testing</artifactId>
-        <version>${version.org.kie}</version>
-        <classifier>sources</classifier>
-      </dependency>
-      <dependency>
-        <groupId>org.drools</groupId>
         <artifactId>drools-wb-scenario-simulation-editor-backend</artifactId>
         <version>${version.org.kie}</version>
       </dependency>

--- a/kie-bom/pom.xml
+++ b/kie-bom/pom.xml
@@ -2473,27 +2473,6 @@
         <classifier>sources</classifier>
       </dependency>
 
-      <!-- Stunner - Kogito-->
-      <dependency>
-        <groupId>org.kie.workbench.stunner</groupId>
-        <artifactId>kie-wb-common-stunner-kogito-client</artifactId>
-        <version>${version.org.kie}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.kie.workbench.stunner</groupId>
-        <artifactId>kie-wb-common-stunner-kogito-client</artifactId>
-        <version>${version.org.kie}</version>
-        <classifier>sources</classifier>
-      </dependency>
-
-      <dependency>
-        <groupId>org.kie.workbench.stunner</groupId>
-        <artifactId>kie-wb-common-stunner-kogito-client</artifactId>
-        <version>${version.org.kie}</version>
-        <type>test-jar</type>
-      </dependency>
-
       <!-- Stunner - BPMN-->
 
       <dependency>
@@ -2683,24 +2662,6 @@
         <classifier>sources</classifier>
       </dependency>
 
-      <!-- Stunner - DMN Editor - Kogito-->
-      <dependency>
-        <groupId>org.kie.workbench</groupId>
-        <artifactId>kie-wb-common-dmn-webapp-kogito-common</artifactId>
-        <version>${version.org.kie}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.kie.workbench</groupId>
-        <artifactId>kie-wb-common-dmn-webapp-kogito-common</artifactId>
-        <version>${version.org.kie}</version>
-        <classifier>sources</classifier>
-      </dependency>
-      <dependency>
-        <groupId>org.kie.workbench</groupId>
-        <artifactId>kie-wb-common-dmn-webapp-kogito-common</artifactId>
-        <version>${version.org.kie}</version>
-        <type>test-jar</type>
-      </dependency>
       <dependency>
         <groupId>org.kie.workbench</groupId>
         <artifactId>kie-wb-common-dmn-webapp-kogito-marshaller</artifactId>
@@ -2709,41 +2670,6 @@
       <dependency>
         <groupId>org.kie.workbench</groupId>
         <artifactId>kie-wb-common-dmn-webapp-kogito-marshaller</artifactId>
-        <version>${version.org.kie}</version>
-        <classifier>sources</classifier>
-      </dependency>
-
-      <!--Kogito-->
-      <dependency>
-        <groupId>org.kie.workbench</groupId>
-        <artifactId>kie-wb-common-kogito-api</artifactId>
-        <version>${version.org.kie}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.kie.workbench</groupId>
-        <artifactId>kie-wb-common-kogito-api</artifactId>
-        <version>${version.org.kie}</version>
-        <classifier>sources</classifier>
-      </dependency>
-      <dependency>
-        <groupId>org.kie.workbench</groupId>
-        <artifactId>kie-wb-common-kogito-client</artifactId>
-        <version>${version.org.kie}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.kie.workbench</groupId>
-        <artifactId>kie-wb-common-kogito-client</artifactId>
-        <version>${version.org.kie}</version>
-        <classifier>sources</classifier>
-      </dependency>
-      <dependency>
-        <groupId>org.kie.workbench</groupId>
-        <artifactId>kie-wb-common-kogito-webapp-base</artifactId>
-        <version>${version.org.kie}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.kie.workbench</groupId>
-        <artifactId>kie-wb-common-kogito-webapp-base</artifactId>
         <version>${version.org.kie}</version>
         <classifier>sources</classifier>
       </dependency>

--- a/kie-bom/pom.xml
+++ b/kie-bom/pom.xml
@@ -2517,32 +2517,6 @@
 
       <dependency>
         <groupId>org.kie.workbench.stunner</groupId>
-        <artifactId>kie-wb-common-stunner-bpmn-emf</artifactId>
-        <version>${version.org.kie}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.kie.workbench.stunner</groupId>
-        <artifactId>kie-wb-common-stunner-bpmn-emf</artifactId>
-        <version>${version.org.kie}</version>
-        <classifier>sources</classifier>
-      </dependency>
-
-      <dependency>
-        <groupId>org.kie.workbench.stunner</groupId>
-        <artifactId>kie-wb-common-stunner-bpmn-marshalling</artifactId>
-        <version>${version.org.kie}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.kie.workbench.stunner</groupId>
-        <artifactId>kie-wb-common-stunner-bpmn-marshalling</artifactId>
-        <version>${version.org.kie}</version>
-        <classifier>sources</classifier>
-      </dependency>
-
-      <dependency>
-        <groupId>org.kie.workbench.stunner</groupId>
         <artifactId>kie-wb-common-stunner-bpmn-client</artifactId>
         <version>${version.org.kie}</version>
       </dependency>

--- a/uberfire-bom/pom.xml
+++ b/uberfire-bom/pom.xml
@@ -1476,19 +1476,6 @@
         <classifier>sources</classifier>
       </dependency>
 
-      <!-- Appformer Kogito-->
-      <dependency>
-        <groupId>org.uberfire</groupId>
-        <artifactId>appformer-kogito-bridge</artifactId>
-        <version>${version.org.uberfire}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.uberfire</groupId>
-        <artifactId>appformer-kogito-bridge</artifactId>
-        <version>${version.org.uberfire}</version>
-        <classifier>sources</classifier>
-      </dependency>
-
       <!-- Dashbuilder APIs -->
       <dependency>
         <groupId>org.dashbuilder</groupId>


### PR DESCRIPTION
**Thank you for submitting this pull request**

**JIRA**: [KOGITO-5016](https://issues.redhat.com/browse/KOGITO-5016)

**referenced Pull Requests**:

- https://github.com/kiegroup/appformer/pull/1135
- https://github.com/kiegroup/kie-wb-common/pull/3632
- https://github.com/kiegroup/drools-wb/pull/1488
- https://github.com/kiegroup/jbpm-wb/pull/1490
- https://github.com/kiegroup/kie-wb-distributions/pull/1099

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
