### PR TITLE
[RHPAM-3489][RHDM-1623] duplicated version.org.apache.xmlgraphics.commons error fixed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -299,7 +299,6 @@
     <version.org.drools.droolsjbpm-tools>${version.org.drools}</version.org.drools.droolsjbpm-tools>
     <version.org.jbpm.jbpm-designer>${version.org.jbpm}</version.org.jbpm.jbpm-designer>
     <version.org.jbpm.jbpm-wb>${version.org.jbpm}</version.org.jbpm.jbpm-wb>
-    <version.org.apache.xmlgraphics.commons>2.2</version.org.apache.xmlgraphics.commons>
 
     <!-- External dependency versions bom -->
     <!-- ################################################################################ -->


### PR DESCRIPTION
**Thank you for submitting this pull request**

Related PRs:

- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1645

`version.org.apache.xmlgraphics.commons` repeated on:

- https://github.com/kiegroup/droolsjbpm-build-bootstrap/blob/548244ff02e5dc8749229e4ff060f29a04532a7e/pom.xml#L302
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/blob/548244ff02e5dc8749229e4ff060f29a04532a7e/pom.xml#L163

**JIRA**: 

- https://issues.redhat.com/browse/RHPAM-3489
- https://issues.redhat.com/browse/RHDM-1623


<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
