### PR TITLE
[DROOLS-6369] Fix kie-karaf-itests failures because of guava upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,7 @@
     <version.org.jresearch.gwt.time>2.0.3</version.org.jresearch.gwt.time>
     <version.domino-slf4j-logger>1.0.1</version.domino-slf4j-logger>
     <version.com.google.guava>30.0-jre</version.com.google.guava>
+    <!-- failureaccess is required for karaf features.xml to expose com.google.common.util.concurrent.internal package -->
     <version.com.google.guava.failureaccess>1.0.1</version.com.google.guava.failureaccess>
     <version.com.google.inject.guice>4.0</version.com.google.inject.guice>
     <version.com.google.gwt>2.9.0</version.com.google.gwt>


### PR DESCRIPTION
- Additional comment

**JIRA**: 

https://issues.redhat.com/browse/DROOLS-6369

**referenced Pull Requests**: 

* Addition to https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1652

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest</b> (using <i>this</i> e.g. <b>Jenkins retest this</b> optional but no longer required)
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
