### PR TITLE
BAQE-1904 - Change revapi to check against 7.52.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -445,7 +445,7 @@
 
 
     <!-- Latest release to be used by api-compatibility-check to check backwards compatibility of the Kie API. -->
-    <revapi.oldKieVersion>7.48.0.Final</revapi.oldKieVersion>
+    <revapi.oldKieVersion>7.52.0.Final</revapi.oldKieVersion>
     <revapi.newKieVersion>${project.version}</revapi.newKieVersion>
 
     <version.org.jboss.spec.javax.websocket>1.1.3.Final</version.org.jboss.spec.javax.websocket>


### PR DESCRIPTION
**JIRA**: [BAQE-1904](https://issues.redhat.com/browse/BAQE-1904)

PR set:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1665
* https://github.com/kiegroup/appformer/pull/1150
* https://github.com/kiegroup/droolsjbpm-knowledge/pull/525
* https://github.com/kiegroup/drools/pull/3664
* https://github.com/kiegroup/jbpm/pull/1948
* https://github.com/kiegroup/droolsjbpm-integration/pull/2503
* https://github.com/kiegroup/optaplanner/pull/1370
