### PR TITLE
PLANNER-2446: Always archive screenshots and videos

### DIFF
--- a/.ci/pull-request-config.yaml
+++ b/.ci/pull-request-config.yaml
@@ -59,14 +59,14 @@ build:
   - project: kiegroup/optaweb-employee-rostering
     archive-artifacts:
       path: |
-        **/cypress/screenshots/**
-        **/cypress/videos/**
+        **/cypress/screenshots/**@always
+        **/cypress/videos/**@always
 
   - project: kiegroup/optaweb-vehicle-routing
     archive-artifacts:
       path: |
-        **/cypress/screenshots/**
-        **/cypress/videos/**
+        **/cypress/screenshots/**@always
+        **/cypress/videos/**@always
 
   - project: kiegroup/kie-wb-distributions
     build-command:


### PR DESCRIPTION
By default, each path is only uploaded when the build is successful.

https://github.com/kiegroup/github-action-build-chain/blob/master/README.md#upload-for-different-execution-results

In case of OptaWeb, we need the artifacts always. Especially when the
end-to-end test fails so that we can see what went wrong.

**JIRA**:

https://issues.redhat.com/browse/PLANNER-2446

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest</b> (using <i>this</i> e.g. <b>Jenkins retest this</b> optional but no longer required)
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
