### PR TITLE
allow jdk/maven tool per job

### DIFF
--- a/Jenkinsfile.buildchain
+++ b/Jenkinsfile.buildchain
@@ -7,6 +7,8 @@ additionalExcludedArtifacts = "${env.ADDITIONAL_EXCLUDED_ARTIFACTS?.trim() ?: ''
 checkstyleFile = env.CHECKSTYLE_FILE?.trim() ?: null
 findbugsFile = env.FINDBUGS_FILE?.trim() ?: null
 pr_type = env.PR_TYPE?.trim() ?: null
+build_jdk_tool = env.BUILD_JDK_TOOL?.trim() ?: 'kie-jdk8'
+build_maven_tool = env.BUILD_MAVEN_TOOL?.trim() ?: 'kie-maven-3.6.3'
 
 pipeline {
     agent {
@@ -44,6 +46,10 @@ pipeline {
             }
         }
         stage('Build projects') {
+            tools {
+              jdk build_jdk_tool
+              maven build_maven_tool
+            }
             steps {
                 script {
                     def buildChainActionInfo =


### PR DESCRIPTION
**Thank you for submitting this pull request**

related PRs:

- https://github.com/kiegroup/kie-jenkins-scripts/pull/1011

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest</b> (using <i>this</i> e.g. <b>Jenkins retest this</b> optional but no longer required)
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
