### PR TITLE
skipping tests to re-generate that artifacts to upload to filemgmt.jb…

### DIFF
--- a/script/release/05a_communityDeployLocally.sh
+++ b/script/release/05a_communityDeployLocally.sh
@@ -3,5 +3,5 @@
 deployDir=$WORKSPACE/community-deploy-dir
 # does a full build, but deploys only into local dir
 # we will deploy into remote staging repo only once the whole build passed (to save time and bandwith)
-./droolsjbpm-build-bootstrap/script/mvn-all.sh -B -e -U clean deploy -s $SETTINGS_XML_FILE -Dkie.maven.settings.custom=$SETTINGS_XML_FILE -Dfull -Drelease -DaltDeploymentRepository=local::default::file://$deployDir -Dmaven.test.failure.ignore=true -Dgwt.memory.settings="-Xmx10g"
+./droolsjbpm-build-bootstrap/script/mvn-all.sh -B -e -U clean deploy -s $SETTINGS_XML_FILE -Dkie.maven.settings.custom=$SETTINGS_XML_FILE -Dfull -Drelease -DaltDeploymentRepository=local::default::file://$deployDir -DskipTests -Dgwt.memory.settings="-Xmx10g"
 


### PR DESCRIPTION
…oos.org

the pipeline has to run again since due Jenkins master instabilities the file that should be archived with the needed binaries for the webs isn't available. So this the built has to be re-run with skipping test

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest</b> (using <i>this</i> e.g. <b>Jenkins retest this</b> optional but no longer required)
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
