### PR TITLE
exit a sh scripts when git-all.sh fails

### DIFF
--- a/script/git-all.sh
+++ b/script/git-all.sh
@@ -64,6 +64,7 @@ startDateTime=`date +%s`
 echo "Git arg. line=${GIT_ARG_LINE[@]}"
 cd "$droolsjbpmOrganizationDir"
 
+exitCode=0
 for repository in $REPOSITORY_LIST ; do
     echo
     if [ ! -d "$droolsjbpmOrganizationDir/$repository" ]; then
@@ -81,6 +82,7 @@ for repository in $REPOSITORY_LIST ; do
         returnCode=$?
         cd ..
         if [ $returnCode != 0 ] ; then
+            exitCode=returnCode
             echo -n "Error executing command for repository ${repository}. Should I continue? (Hit control-c to stop or enter to continue): "
             read ok
         fi
@@ -92,3 +94,5 @@ spentSeconds=`expr $endDateTime - $startDateTime`
 
 echo
 echo "Total time: ${spentSeconds}s"
+
+exit $exitCode


### PR DESCRIPTION
**Thank you for submitting this pull request**

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest</b> (using <i>this</i> e.g. <b>Jenkins retest this</b> optional but no longer required)
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
