### PR TITLE
added new repo to update script

### DIFF
--- a/script/release/update-version-all.sh
+++ b/script/release/update-version-all.sh
@@ -197,6 +197,13 @@ for repository in `cat ${scriptDir}/../repository-list.txt` ; do
             returnCode=$?
             sed -i "s/release.version=.*$/release.version=$newVersion/" jbpm-installer/src/main/resources/build.properties
 
+        elif [ "$repository" == "process-migration-service" ]; then
+            # extract old kie version
+            kieOldVersion=$(grep -oP -m 1 '(?<=<version>).*(?=</version)' pom.xml)
+          # update version since no mvn command works
+            sed -i "s/<version>$kieOldVersion<\/version>/<version>$newVersion<\/version>/" pom.xml
+            returnCode=$?
+
         else
             mvnVersionsUpdateParentAndChildModules
             returnCode=$?


### PR DESCRIPTION
**Thank you for submitting this pull request**
Since process-migration-service is a new repo in kiegroup with dependencies of droolsjbpm-integration, its version should be synced to all other community repos. Since no `mvn` command for updating works there is a simple `sed` command executed when running the scipt for upgrading the versions in all kiegroup repos.  

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest</b> (using <i>this</i> e.g. <b>Jenkins retest this</b> optional but no longer required)
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
