### PR TITLE
Revert "Downgrade Maven to 3.6.3"

### DIFF
--- a/.ci/jenkins/Jenkinsfile.nightly
+++ b/.ci/jenkins/Jenkinsfile.nightly
@@ -5,7 +5,7 @@ pipeline {
         label 'kie-rhel7 && kie-mem24g && !master'
     }
     tools {
-        maven 'kie-maven-3.6.3'
+        maven 'kie-maven-3.8.1'
         jdk 'kie-jdk1.8'
     }
     parameters {


### PR DESCRIPTION
Reverts kiegroup/droolsjbpm-build-bootstrap#1690