### PR TITLE
enhanced git-clone-all for main branch

### DIFF
--- a/.ci/jenkins/Jenkinsfile.nightly
+++ b/.ci/jenkins/Jenkinsfile.nightly
@@ -52,7 +52,7 @@ pipeline {
                             def projectCollection = communityProjectListFile.readLines()
                             def productionProjectListFile = readFile "${env.PRODUCTION_PROJECT_LIST}"
                             projectCollection.addAll(productionProjectListFile.readLines())
-                            projectCollection.removeAll { 'droolsjbpm-tools'.equals(it.toLowerCase()) } // The droolsjbpm-tools is skiped
+                            projectCollection.removeAll { ['droolsjbpm-tools', 'process-migration-service'].contains(it.toLowerCase()) } // The droolsjbpm-tools and process-migration-service repos are skipped
                             println "File ${repositoryListPath} and ${env.PRODUCTION_PROJECT_LIST} jenkins file merged in ${projectCollection}"
 
                             def currentBranch = env.BRANCH_NAME ?: env.GIT_BRANCH

--- a/script/git-clone-others.sh
+++ b/script/git-clone-others.sh
@@ -57,6 +57,8 @@ additionalGitOptions=()
 REPOSITORY_LIST=`cat "${scriptDir}/repository-list.txt"`
 # Repositories that need to use the branch 7.x instead of master
 BRANCHED_7_REPOSITORY_LIST=`cat "${scriptDir}/branched-7-repository-list.txt"`
+# Repositories thta ned to use branch main instead of master
+MAIN_BRANCH_REPOSITORIES_LIST=`cat "${scriptDir}/main-branch-repositories-list.txt"`
 
 for arg in "$@"
 do
@@ -115,6 +117,16 @@ for repository in $REPOSITORY_LIST ; do
                 fi
             else
                 repoAdditionalGitOptions=( "-b" "7.x" "${repoAdditionalGitOptions[@]}" )
+            fi
+        fi
+        if [ $(echo "$MAIN_BRANCH_REPOSITORIES_LIST" | grep "^$repository$") ] ; then
+            if [[ ${additionalGitOptions[0]} == "-b" ]] || [[ ${additionalGitOptions[0]} == "--branch" ]]; then
+                if [[ ${additionalGitOptions[1]} == "master" ]]; then
+                  repoAdditionalGitOptions[1]="main"
+                  echo -- additional Git options changed in ${repository} to: ${repoAdditionalGitOptions[@]} --
+                fi
+            else
+                repoAdditionalGitOptions=( "-b" "main" "${repoAdditionalGitOptions[@]}" )
             fi
         fi
         git clone "${repoAdditionalGitOptions[@]}" ${gitUrlPrefix}${repository}.git ${repository}

--- a/script/main-branch-repositories-list.txt
+++ b/script/main-branch-repositories-list.txt
@@ -1,0 +1,1 @@
+process-migration-service


### PR DESCRIPTION
**Thank you for submitting this pull request**

Since `process-migration-service` became a new repo in repository-list.txt but the main branch instead of `master` it is `main`, the same logic we applied for opta* `7.x` branches was applied for this repo too.
All daily builds are failing because the `master` branch on `process-migration-service` can't be cloned.
`git-clone-others.sh` is needed (via[ 01_clonebranches.sh](https://github.com/kiegroup/droolsjbpm-build-bootstrap/blob/master/script/release/01_cloneBranches.sh)) in

- [communityRelease_pipeline](https://github.com/kiegroup/kie-jenkins-scripts/blob/master/job-dsls/jobs/kie/master/communityRelease_pipeline.groovy#L93) 
- [prodTag](https://github.com/kiegroup/kie-jenkins-scripts/blob/master/job-dsls/jobs/kie/master/prodTag_pipeline.groovy#L75)
- [dailyBuild_pipeline](https://github.com/kiegroup/kie-jenkins-scripts/blob/master/job-dsls/jobs/kie/master/dailyBuild_pipeline.groovy#L83)
- [dailyBuild_prod_pipeline](https://github.com/kiegroup/kie-jenkins-scripts/blob/master/job-dsls/jobs/kie/master/dailyBuild_prod_pipeline.groovy#L75)
- [dailyBuild_jdk11_pipeline](https://github.com/kiegroup/kie-jenkins-scripts/blob/master/job-dsls/jobs/kie/master/dailyBuild_jdk11_pipeline.groovy#L77)

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest</b> (using <i>this</i> e.g. <b>Jenkins retest this</b> optional but no longer required)
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
