### PR TITLE
[RHPAM-3825] - Downgrade xercesImpl from 2.12.1 to 2.12.0.SP03 found…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -285,7 +285,7 @@
     <version.tomcat>9.0.22</version.tomcat>
     <version.wsdl4j>1.6.3</version.wsdl4j>
     <version.xalan>2.7.1</version.xalan>
-    <version.xerces>2.12.1</version.xerces>
+    <version.xerces>2.12.0.SP03</version.xerces>
     <version.xml-apis>1.4.01</version.xml-apis>
     <version.xml-apis-ext>1.3.04</version.xml-apis-ext>
     <version.xml-resolver>1.2</version.xml-resolver>


### PR DESCRIPTION
… in WildFly 23/EAP 7.4

Reverts #1669

**JIRA**: [BXMSPROD-1433](https://issues.redhat.com/browse/BXMSPROD-1433) moved to https://issues.redhat.com/browse/RHPAM-3825

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest</b> (using <i>this</i> e.g. <b>Jenkins retest this</b> optional but no longer required)
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
