### PR TITLE
PLANNER-2487: Remove wildfly from OptaWeb build commands

### DIFF
--- a/.ci/pull-request-config.yaml
+++ b/.ci/pull-request-config.yaml
@@ -57,12 +57,16 @@ build:
       current: mvn -e clean install -Dmaven.test.failure.ignore=true -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
 
   - project: kiegroup/optaweb-employee-rostering
+    build-command:
+      current: mvn -e -nsu clean install -Dfull -Prun-code-coverage -Dintegration-tests=true -Dmaven.test.failure.ignore=true -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3
     archive-artifacts:
       path: |
         **/cypress/screenshots/**@always
         **/cypress/videos/**@always
 
   - project: kiegroup/optaweb-vehicle-routing
+    build-command:
+      current: mvn -e -nsu clean install -Dfull -Prun-code-coverage -Dintegration-tests=true -Dmaven.test.failure.ignore=true -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3
     archive-artifacts:
       path: |
         **/cypress/screenshots/**@always


### PR DESCRIPTION
Should eliminate the following false warning:

![Selection_030](https://user-images.githubusercontent.com/673386/128180056-7b449614-7a51-41ee-8668-c7974a991d14.png)


<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest</b> (using <i>this</i> e.g. <b>Jenkins retest this</b> optional but no longer required)
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
