### PR TITLE
[DROOLS-6554] droolsjbpm-integration deploy job failure

### DIFF
--- a/kie-pmml-bom/pom.xml
+++ b/kie-pmml-bom/pom.xml
@@ -448,6 +448,14 @@
       </dependency>
       <dependency>
         <groupId>org.kie</groupId>
+        <artifactId>kie-pmml-compiler-api</artifactId>
+        <version>${version.org.kie}</version>
+        <type>test-jar</type>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.kie</groupId>
         <artifactId>kie-pmml-compiler-commons</artifactId>
         <classifier>tests</classifier>
         <version>${version.org.kie}</version>


### PR DESCRIPTION
**JIRA**: 

https://issues.redhat.com/browse/DROOLS-6554

**referenced Pull Requests**:

https://github.com/kiegroup/droolsjbpm-integration/pull/2575

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest</b> (using <i>this</i> e.g. <b>Jenkins retest this</b> optional but no longer required)
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
