### PR TITLE
Bump keycloak-core from 9.0.3 to 13.0.0 (#1664)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -241,7 +241,7 @@
     <version.org.json>20090211</version.org.json>
     <version.org.jsoup>1.8.3</version.org.jsoup>
     <version.org.junit>5.5.2</version.org.junit>
-    <version.org.keycloak>9.0.3</version.org.keycloak>
+    <version.org.keycloak>13.0.0</version.org.keycloak>
     <version.org.apache.logging.log4j>2.13.2</version.org.apache.logging.log4j>
     <version.org.mvel>2.4.12.Final</version.org.mvel>
     <version.org.ocpsoft.prettytime>3.0.2.Final</version.org.ocpsoft.prettytime>


### PR DESCRIPTION
backport of https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1664