### PR TITLE
removed process-migration-services from repository-list only when usi…

### DIFF
--- a/script/mvn-all.sh
+++ b/script/mvn-all.sh
@@ -38,7 +38,10 @@ initializeWorkingDirAndScriptDir
 droolsjbpmOrganizationDir="$scriptDir/../.."
 
 # default repository list is stored in the repository-list.txt file
-REPOSITORY_LIST=`cat "${scriptDir}/repository-list.txt"`
+# REPOSITORY_LIST=`cat "${scriptDir}/repository-list.txt"`
+# since process-migration-service has to be compiled with jdk11 as workaround we will remove this rep from he list
+# since all jobs using mvn-all.sh are using jdk1.8
+REPOSITORY_LIST=`cat "${scriptDir}/repository-list.txt" | sed 's/process-migration-service//g'`
 MVN_ARG_LINE=()
 
 for arg in "$@"


### PR DESCRIPTION
…ng mvn-all.sh

(cherry picked from commit eeb24ad67219a68eaaea5e2dcf0aa83ef8e8d119)

Merge together with https://github.com/kiegroup/kie-jenkins-scripts/pull/1093

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest</b> (using <i>this</i> e.g. <b>Jenkins retest this</b> optional but no longer required)
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
