### PR TITLE
BXMSPROD-1468: skipping to build PIM when using jdk1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -370,6 +370,7 @@
     <org.kie.productized>false</org.kie.productized>
 
     <maven.build.timestamp.format>yyyyMMddHHmm</maven.build.timestamp.format>
+
     <!-- This property needs to be defined in all modules that use the packaging 'jar' or 'bundle'. It is
          being used by different plugins to make sure the module/bundle names are consistent. -->
     <java.module.name/>
@@ -2050,6 +2051,7 @@
       </activation>
       <properties>
         <javadoc.additional.params>-Xdoclint:none</javadoc.additional.params>
+        <maven.compiler.release>8</maven.compiler.release>
       </properties>
       <build>
         <pluginManagement>

--- a/script/mvn-all.sh
+++ b/script/mvn-all.sh
@@ -37,11 +37,16 @@ printUsage() {
 initializeWorkingDirAndScriptDir
 droolsjbpmOrganizationDir="$scriptDir/../.."
 
-# default repository list is stored in the repository-list.txt file
-# REPOSITORY_LIST=`cat "${scriptDir}/repository-list.txt"`
-# since process-migration-service has to be compiled with jdk11 as workaround we will remove this rep from he list
-# since all jobs using mvn-all.sh are using jdk1.8
-REPOSITORY_LIST=`cat "${scriptDir}/repository-list.txt" | sed 's/process-migration-service//g'`
+JAVA_VERSION=$(java -version 2>&1 | grep "version" | sed 's/.*"\(.*\)".*/\1/')
+if [[ "$JAVA_VERSION" =~ ^1.8.* ]]; then
+  # PIM (process-migration-service) has to be compiled with jdk11.
+  # As workaround we will remove this rep from the list since all jobs using mvn-all.sh are using jdk1.8
+  REPOSITORY_LIST=`cat "${scriptDir}/repository-list.txt" | sed '/process-migration-service/d'`
+else
+  # default repository list is stored in the repository-list.txt file
+  REPOSITORY_LIST=`cat "${scriptDir}/repository-list.txt"`
+fi
+
 MVN_ARG_LINE=()
 
 for arg in "$@"


### PR DESCRIPTION
**Thank you for submitting this pull request**

**JIRA**: [BXMSPROD-1468](https://issues.redhat.com/browse/BXMSPROD-1468)


- when the reps are build with >= jdk11 the jars will be compiled the jdk1.8 could read them
- when the JAVA version for compiling the reps is **jdk 1.8** the mvn-all.sh scripts skips PIM,  removing this project from repository-list.txt 

Works locally. 
mvn-all.sh was used with jdk1.8 and jdk11, it worked.
In case the build was with jdk 11, a *.jar was downloaded, a class extracted and 
`javap -v XXX.class | grep major` done with 52 (for jdk1.8) as result.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest</b> (using <i>this</i> e.g. <b>Jenkins retest this</b> optional but no longer required)
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
