### PR TITLE
skipped process-migration-service for fdb and cdb

### DIFF
--- a/.ci/compilation-config.yaml
+++ b/.ci/compilation-config.yaml
@@ -36,6 +36,9 @@ build:
       path: |
         **/target/screenshots/**
 
+  - project: kiegroup/process-migration-service
+    skip: true
+    
   - project: kiegroup/kie-docs
     skip: true
 

--- a/.ci/full-downstream-config.yaml
+++ b/.ci/full-downstream-config.yaml
@@ -41,8 +41,12 @@ build:
       current: mvn -e -nsu -B --builder smart -T1C clean install -Dfull -Pjenkins-pr-builder -DskipTests -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3
       downstream: mvn -e -nsu clean install -Dfull -Pbusiness-central,wildfly,sourcemaps,no-showcase,jenkins-pr-builder -Dcontainer=wildfly -Dcontainer.profile=wildfly -Dintegration-tests=true -Dcargo.ignore.failures=true -Dmaven.test.failure.ignore=true -Dmaven.test.redirectTestOutputToFile=true -Dgwt.compiler.localWorkers=1 -Dwebdriver.firefox.bin=/opt/tools/firefox-60esr/firefox-bin -Dgwt.skipCompilation=true -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3
 
+  - project: kiegroup/process-migration-service
+    skip: true
+
   - project: kiegroup/kie-docs
     skip: true
 
   - project: kiegroup/droolsjbpm-tools
     skip: true
+

--- a/.ci/project-dependencies.yaml
+++ b/.ci/project-dependencies.yaml
@@ -157,3 +157,7 @@ dependencies:
       - project: kiegroup/appformer
       - project: kiegroup/kie-uberfire-extensions
       - project: kiegroup/optaplanner-wb
+
+  - project: kiegroup/process-migration-service
+    dependencies:
+      - project: kiegroup/droolsjbpm-integration

--- a/.ci/pull-request-config.yaml
+++ b/.ci/pull-request-config.yaml
@@ -82,7 +82,3 @@ build:
         **/target/business-central*eap*.war
         **/target/business-central*wildfly*.war
         **/target/jbpm-server*dist*.zip
-
-  - project: kiegroup/process-migration-service
-    dependencies:
-      - project: kiegroup/droolsjbpm-integration


### PR DESCRIPTION
**Thank you for submitting this pull request**

- with this the repository-list.txt will have again, when created `process-migratopn-service`
- fdb and cdb are skipping PIM

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest</b> (using <i>this</i> e.g. <b>Jenkins retest this</b> optional but no longer required)
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
