### PR TITLE
[7.59.x] Switch nightly build to JDK11

### DIFF
--- a/.ci/jenkins/Jenkinsfile.nightly
+++ b/.ci/jenkins/Jenkinsfile.nightly
@@ -6,7 +6,7 @@ pipeline {
     }
     tools {
         maven 'kie-maven-3.8.1'
-        jdk 'kie-jdk1.8'
+        jdk 'kie-jdk11'
     }
     parameters {
         string(description: 'The deployment URL', name: 'KIE_GROUP_DEPLOYMENT_REPO_URL')


### PR DESCRIPTION
Signed-off-by: Alberto Morales Perez <almorale@redhat.com>

Backport for: https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1761