### PR TITLE
BXMSPROD-1471: use 7.x branch for Drools and droolsjbpm-knowledge

### DIFF
--- a/script/branched-7-repository-list.txt
+++ b/script/branched-7-repository-list.txt
@@ -1,3 +1,5 @@
+drools
+droolsjbpm-knowledge
 optaplanner
 optaweb-employee-rostering
 optaweb-vehicle-routing


### PR DESCRIPTION
Signed-off-by: Alberto Morales Perez <almorale@redhat.com>

Backport for: https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1764