### PR TITLE
JBPM-9896 - Fix dependency for compilation Stunner on JDK 11 to JRE 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -362,7 +362,7 @@
     <version.org.hibernate.hibernate-validator>4.1.0.Final</version.org.hibernate.hibernate-validator>
     <!-- CSS parsing library from Apache used by Stunner. -->
     <version.net.sourceforge.cssparser>0.9.21</version.net.sourceforge.cssparser>
-    <version.org.w3c.css.sac>1.3</version.org.w3c.css.sac>
+    <version.org.w3c.dom>2.3.0-jaxb-1.0.6</version.org.w3c.dom>
     <version.org.mockito>3.6.0</version.org.mockito>
     <!-- Version of JMH -->
     <version.org.openjdk.jmh>1.21</version.org.openjdk.jmh>
@@ -6227,9 +6227,9 @@
         <version>${version.net.sourceforge.cssparser}</version>
       </dependency>
       <dependency>
-        <groupId>org.w3c.css</groupId>
-        <artifactId>sac</artifactId>
-        <version>${version.org.w3c.css.sac}</version>
+        <groupId>org.w3c</groupId>
+        <artifactId>dom</artifactId>
+        <version>${version.org.w3c.dom}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Hi @mareknovotny, @romartin, @domhanak,

I fixed the dependency, issue was when we compiling with JDK 11 for JDK 8 there are some collisions with XML API names. Since this dependency was used only for Stunner (according to comments into the POM) file, so I updated it directly without adding new dependencies.

**referenced Pull Requests**: 

* https://github.com/kiegroup/kie-wb-common/pull/3682
* https://github.com/kiegroup/jbpm-wb/pull/1513
* https://github.com/kiegroup/kie-wb-distributions/pull/1127
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1766

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest</b> (using <i>this</i> e.g. <b>Jenkins retest this</b> optional but no longer required)
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
