### PR TITLE
[7.59.x] RHPAM-3510: upgrade minor versions (#1736)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <version.ch.qos.logback>1.2.3</version.ch.qos.logback>
     <version.commons-beanutils>1.9.4</version.commons-beanutils>
     <version.commons-cli>1.4</version.commons-cli>
-    <version.commons-codec>1.11</version.commons-codec>
+    <version.commons-codec>1.15</version.commons-codec>
     <version.commons-collections>3.2.2</version.commons-collections>
     <version.commons-configuration>1.6</version.commons-configuration>
     <version.commons-dbcp>1.4</version.commons-dbcp>
@@ -133,7 +133,7 @@
     <version.org.apache.commons.compress>1.19</version.org.apache.commons.compress>
     <version.org.apache.commons.csv>1.6</version.org.apache.commons.csv>
     <version.org.apache.commons.exec>1.3</version.org.apache.commons.exec>
-    <version.org.apache.commons.lang3>3.9</version.org.apache.commons.lang3>
+    <version.org.apache.commons.lang3>3.11</version.org.apache.commons.lang3>
     <version.org.apache.commons.math>2.1</version.org.apache.commons.math>
     <version.org.apache.commons.math3>3.4.1</version.org.apache.commons.math3>
     <version.org.apache.commons.pool2>2.4.2</version.org.apache.commons.pool2>
@@ -450,7 +450,7 @@
     <version.mariadb-java-client>1.3.4</version.mariadb-java-client>
 
     <version.ch.obermuhlner>2.0.1</version.ch.obermuhlner>
-    <version.org.jboss.jandex>2.1.1.Final</version.org.jboss.jandex>
+    <version.org.jboss.jandex>2.2.3.Final</version.org.jboss.jandex>
     <version.jandex.plugin>1.0.6</version.jandex.plugin>
     <version.org.eclipse.yasson>1.0.6</version.org.eclipse.yasson>
     <version.com.sun.xml.messaging.saaj>1.5.0</version.com.sun.xml.messaging.saaj>


### PR DESCRIPTION
* RHPAM-3510: upgrade minor versions

* downgrade back sshd to 2.3.0

* Cancel Update of version.org.glassfish.jaxb

Co-authored-by: Marek Novotný <hotmana76@gmail.com>
(cherry picked from commit 3cb53e14fb20368dd995258866209863ade5f8d9)

**Thank you for submitting this pull request**
**JIRA**: [RHPAM-3510](https://issues.redhat.com/browse/RHPAM-3510)

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest</b> (using <i>this</i> e.g. <b>Jenkins retest this</b> optional but no longer required)
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
