### PR TITLE
[7.59.x] call method that removes partially downloaded deps in .m2 before the …

### DIFF
--- a/.ci/jenkins/Jenkinsfile.buildchain
+++ b/.ci/jenkins/Jenkinsfile.buildchain
@@ -45,6 +45,13 @@ pipeline {
                 }
             }
         }
+        stage('Remove partially downloaded deps') {
+            steps {
+                script{
+                    util.rmPartialDeps()
+                }
+            }
+        }
         stage('Build projects') {
             tools {
               jdk build_jdk_tool


### PR DESCRIPTION
…build starts (#1772)

(cherry picked from commit 7858468388b3af229337659ec38aed15f68953bc)

**Thank you for submitting this pull request**


<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest</b> (using <i>this</i> e.g. <b>Jenkins retest this</b> optional but no longer required)
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
