### PR TITLE
Removed optaweb exclusion to make Optaplanner build from 7.x branch

### DIFF
--- a/.ci/project-dependencies.yaml
+++ b/.ci/project-dependencies.yaml
@@ -33,6 +33,9 @@ dependencies:
           - source: main
             target: 7.x
       exclude:
+        - kiegroup/optaweb-employee-rostering
+        - kiegroup/optaweb-vehicle-routing
+        - kiegroup/optaplanner
         - kiegroup/drools
 
   - project: kiegroup/drools
@@ -49,7 +52,10 @@ dependencies:
           - source: main
             target: 7.x
       exclude:
-        - kiegroup/droolsjbpm-knowledge
+        - kiegroup/optaweb-employee-rostering
+        - kiegroup/optaweb-vehicle-routing
+        - kiegroup/optaplanner          
+        - kiegroup/droolsjbpm-knowledge          
 
   - project: kiegroup/jbpm
     dependencies:
@@ -64,6 +70,12 @@ dependencies:
         default:
           - source: 7.x
             target: main
+        kiegroup/drools:
+          - source: main
+            target: 7.x
+        kiegroup/droolsjbpm-knowledge:
+          - source: main
+            target: 7.x
       dependant:
         default:
           - source: main
@@ -71,8 +83,6 @@ dependencies:
       exclude:
         - kiegroup/optaweb-employee-rostering  
         - kiegroup/optaweb-vehicle-routing
-        - kiegroup/drools
-        - kiegroup/droolsjbpm-knowledge
 
   - project: kiegroup/kie-jpmml-integration
     dependencies:
@@ -148,6 +158,12 @@ dependencies:
         default:
           - source: 7.x
             target: main
+        kiegroup/drools:
+          - source: main
+            target: 7.x
+        kiegroup/droolsjbpm-knowledge:
+          - source: main
+            target: 7.x
       dependant:
         default:
           - source: main
@@ -155,8 +171,6 @@ dependencies:
       exclude:
         - kiegroup/optaweb-vehicle-routing  
         - kiegroup/optaplanner
-        - kiegroup/drools
-        - kiegroup/droolsjbpm-knowledge
 
   - project: kiegroup/optaweb-vehicle-routing
     dependencies:
@@ -166,6 +180,12 @@ dependencies:
         default:
           - source: 7.x
             target: main
+        kiegroup/drools:
+          - source: main
+            target: 7.x
+        kiegroup/droolsjbpm-knowledge:
+          - source: main
+            target: 7.x
       dependant:
         default:
           - source: main
@@ -173,8 +193,6 @@ dependencies:
       exclude:
         - kiegroup/optaweb-employee-rostering  
         - kiegroup/optaplanner
-        - kiegroup/drools
-        - kiegroup/droolsjbpm-knowledge
 
 
   - project: kiegroup/kie-wb-distributions

--- a/.ci/project-dependencies.yaml
+++ b/.ci/project-dependencies.yaml
@@ -33,9 +33,6 @@ dependencies:
           - source: main
             target: 7.x
       exclude:
-        - kiegroup/optaweb-employee-rostering
-        - kiegroup/optaweb-vehicle-routing
-        - kiegroup/optaplanner
         - kiegroup/drools
 
   - project: kiegroup/drools
@@ -52,10 +49,7 @@ dependencies:
           - source: main
             target: 7.x
       exclude:
-        - kiegroup/optaweb-employee-rostering
-        - kiegroup/optaweb-vehicle-routing
-        - kiegroup/optaplanner          
-        - kiegroup/droolsjbpm-knowledge          
+        - kiegroup/droolsjbpm-knowledge
 
   - project: kiegroup/jbpm
     dependencies:


### PR DESCRIPTION
https://github.com/kiegroup/drools/pull/3860

* <b>a pull request</b> please add comment: <b>Jenkins retest</b> (using <i>this</i> e.g. <b>Jenkins retest this</b> optional but no longer required)
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
