### PR TITLE
[prod nightly] CONFIG_BRANCH

### DIFF
--- a/.ci/jenkins/Jenkinsfile.nightly
+++ b/.ci/jenkins/Jenkinsfile.nightly
@@ -13,7 +13,7 @@ pipeline {
         booleanParam(description: 'Skip Tests? True as default', name: 'SKIP_TESTS', defaultValue: true)
         string(description: 'The UMB message version', name: 'UMB_VERSION', defaultValue: 'main')
         string(description: 'The product version', name: 'PRODUCT_VERSION')
-        string(description: 'The config repository branch', name: 'DEFAULT_CONFIG_BRANCH', defaultValue: 'main')
+        string(description: 'The config repository branch', name: 'CONFIG_BRANCH', defaultValue: 'main')
     }
     options {
         buildDiscarder logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '10')
@@ -29,7 +29,7 @@ pipeline {
         stage('Clone build configuration repo') {
             steps {
                 script {
-                    def currentBranch = env.DEFAULT_CONFIG_BRANCH ?: env.BRANCH_NAME ?: env.GIT_BRANCH
+                    def currentBranch = env.CONFIG_BRANCH ?: env.DEFAULT_CONFIG_BRANCH ?: env.BRANCH_NAME ?: env.GIT_BRANCH
                     println "Checking out ${env.BUILD_CONFIGURATION_REPO_URL}:${currentBranch} into build_config folder"
                     sh "git clone -b ${currentBranch} --single-branch ${env.BUILD_CONFIGURATION_REPO_URL} build_config"
                 }


### PR DESCRIPTION
**Thank you for submitting this pull request**

`DEFAULT_CONFIG_BRANCH` environment variable and job parameter are colliding and no matter what you set on `DEFAULT_CONFIG_BRANCH` parameter the env value will be always taken. I've even tried to see the differences between using `${env.DEFAULT_CONFIG_BRANCH}` and `${DEFAULT_CONFIG_BRANCH}` and the result is the same, so the only possibility here is to use a different parameter name.
This is producing `7.59.x` prod nightly error due to `rhdm` profile is not set for `rhba` project and `decision-central-eap7-deployable` is not produced so rhba-installer fails.


**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1783
* https://github.com/kiegroup/kie-jenkins-scripts/pull/1124

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest</b> (using <i>this</i> e.g. <b>Jenkins retest this</b> optional but no longer required)
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
