### PR TITLE
BXMSPROD-1467 - Sonarcloud reports zero issues

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -39,7 +39,7 @@ jobs:
           restore-keys: ${{ runner.os }}-${{ matrix.java-version }}-maven${{ matrix.maven-version }}-m2
       - name: Build Chain ${{ matrix.java-version }}. Maven ${{ matrix.maven-version }}
         id: build-chain
-        uses: kiegroup/github-action-build-chain@v2.6.10
+        uses: kiegroup/github-action-build-chain@v2.6.11
         with:
           definition-file: https://raw.githubusercontent.com/${GROUP}/${PROJECT_NAME}/${BRANCH}/.ci/pull-request-config.yaml
         env:

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -20,7 +20,7 @@ jobs:
           java-version: ${{ matrix.java-version }}
       - name: Build Chain ${{ matrix.java-version }}
         id: build-chain
-        uses: kiegroup/github-action-build-chain@v2.6.10
+        uses: kiegroup/github-action-build-chain@v2.6.11
         with:
           definition-file: https://raw.githubusercontent.com/${GROUP}/${PROJECT_NAME}/${BRANCH}/.ci/upstream-config.yaml
         env:


### PR DESCRIPTION
Signed-off-by: Alberto Morales Perez <almorale@redhat.com>

Related PRs:
https://github.com/kiegroup/kie-soup/pull/233
https://github.com/kiegroup/lienzo-core/pull/154
https://github.com/kiegroup/lienzo-tests/pull/128
https://github.com/kiegroup/appformer/pull/1201
https://github.com/kiegroup/kie-uberfire-extensions/pull/126
https://github.com/kiegroup/jbpm/pull/2043
https://github.com/kiegroup/kie-jpmml-integration/pull/68
https://github.com/kiegroup/droolsjbpm-integration/pull/2620
https://github.com/kiegroup/kie-wb-playground/pull/121
https://github.com/kiegroup/kie-wb-common/pull/3691
https://github.com/kiegroup/drools-wb/pull/1518
https://github.com/kiegroup/jbpm-designer/pull/920
https://github.com/kiegroup/jbpm-work-items/pull/221
https://github.com/kiegroup/jbpm-wb/pull/1523
https://github.com/kiegroup/optaplanner-wb/pull/407
https://github.com/kiegroup/kie-wb-distributions/pull/1134
https://github.com/kiegroup/openshift-drools-hacep/pull/120
https://github.com/kiegroup/process-migration-service/pull/30
https://github.com/kiegroup/kie-docs/pull/3928
https://github.com/kiegroup/kogito-apps/pull/1054
https://github.com/kiegroup/kogito-examples/pull/925
https://github.com/kiegroup/kogito-examples/pull/926
https://github.com/kiegroup/kogito-runtimes/pull/1651
https://github.com/kiegroup/kie-jenkins-scripts/pull/1131
https://github.com/kiegroup/droolsjbpm-knowledge/pull/570
https://github.com/kiegroup/droolsjbpm-knowledge/pull/571
https://github.com/kiegroup/drools/pull/3891
https://github.com/kiegroup/drools/pull/3892
https://github.com/kiegroup/optaplanner/pull/1606
https://github.com/kiegroup/optaplanner/pull/1607
https://github.com/kiegroup/optaweb-employee-rostering/pull/700
https://github.com/kiegroup/optaweb-employee-rostering/pull/701
https://github.com/kiegroup/optaweb-vehicle-routing/pull/577
https://github.com/kiegroup/optaweb-vehicle-routing/pull/578