### PR TITLE
drools 7.x mapping

### DIFF
--- a/.ci/project-dependencies.yaml
+++ b/.ci/project-dependencies.yaml
@@ -73,8 +73,12 @@ dependencies:
         kiegroup/drools:
           - source: main
             target: 7.x
+          - source: 7.x
+            target: 7.x
         kiegroup/droolsjbpm-knowledge:
           - source: main
+            target: 7.x
+          - source: 7.x
             target: 7.x
       dependant:
         default:
@@ -161,8 +165,12 @@ dependencies:
         kiegroup/drools:
           - source: main
             target: 7.x
+          - source: 7.x
+            target: 7.x
         kiegroup/droolsjbpm-knowledge:
           - source: main
+            target: 7.x
+          - source: 7.x
             target: 7.x
       dependant:
         default:
@@ -183,8 +191,12 @@ dependencies:
         kiegroup/drools:
           - source: main
             target: 7.x
+          - source: 7.x
+            target: 7.x
         kiegroup/droolsjbpm-knowledge:
           - source: main
+            target: 7.x
+          - source: 7.x
             target: 7.x
       dependant:
         default:
@@ -208,3 +220,4 @@ dependencies:
   - project: kiegroup/process-migration-service
     dependencies:
       - project: kiegroup/droolsjbpm-integration
+


### PR DESCRIPTION
we could use 
```
        kiegroup/drools:
          - source: .*
            target: 7.x
```            
but I think this is not totally right...

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest</b> (using <i>this</i> e.g. <b>Jenkins retest this</b> optional but no longer required)
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
