### PR TITLE
AF-2880 - [fix] Remove test scope from wildfly-client-config dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5394,7 +5394,6 @@
         <groupId>org.wildfly.client</groupId>
         <artifactId>wildfly-client-config</artifactId>
         <version>${version.org.wildfly.client}</version>
-        <scope>test</scope>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Test scope definition is a too big constraint. We use it in kie-benchmarks repository for performance tests and they need it on the compile classpath.

@Rikkola @mareknovotny Are you ok with that?

Fixes kiegroup/kie-benchmarks#140

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest</b> (using <i>this</i> e.g. <b>Jenkins retest this</b> optional but no longer required)
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
