### PR TITLE
removed kie-jpmml-integration as dependency from droolsjbpm-integration

### DIFF
--- a/.ci/project-dependencies.yaml
+++ b/.ci/project-dependencies.yaml
@@ -96,7 +96,6 @@ dependencies:
   - project: kiegroup/droolsjbpm-integration
     dependencies:
       - project: kiegroup/optaplanner
-      - project: kiegroup/kie-jpmml-integration
       - project: kiegroup/drools
       - project: kiegroup/jbpm
 


### PR DESCRIPTION
**Thank you for submitting this pull request**

**JIRA**: _(please edit the JIRA link if it exists)_ 

[BXMSPROD-1444](https://issues.redhat.com/browse/BXMSPROD-1444)

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_
https://github.com/kiegroup/kie-jenkins-scripts/pull/1153
https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1801

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest</b> (using <i>this</i> e.g. <b>Jenkins retest this</b> optional but no longer required)
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
