### PR TITLE
BXMSPROD-1505 RHDM UMB message removed

### DIFF
--- a/.ci/jenkins/Jenkinsfile.nightly
+++ b/.ci/jenkins/Jenkinsfile.nightly
@@ -130,28 +130,6 @@ pipeline {
                 }
             }
         }
-        stage ("Send RHDM UMB Message to QE.") {
-            steps {
-                script {
-                    echo "[INFO] Sending RHDM UMB message to QE."
-                    def PME_BUILD_VARIABLES = env.PME_BUILD_VARIABLES.split(";").collect{ it.split("=")}.inject([:]) {map, item -> map << [(item.length == 2 ? item[0] : null): (item.length == 2 ? item[1] : null)]}
-
-                    def propertiesFileUrl = "${env.STAGING_SERVER_URL}/rhdm/RHDM-${PME_BUILD_VARIABLES['productVersion']}.${PME_BUILD_VARIABLES['milestone']}/rhdm-${PME_BUILD_VARIABLES['datetimeSuffix']}.properties"
-                    def topic = "VirtualTopic.qe.ci.ba.rhdm.${env.UMB_VERSION}.nightly.trigger"
-                    def eventType = "rhdm-${env.UMB_VERSION}-nightly-qe-trigger"
-
-                    echo "[INFO] Message Body: ${propertiesFileUrl}"
-                    echo "[INFO] Topic: ${topic}"
-                    echo "[INFO] Event Type: ${eventType}"
-                    build job: env.SEND_UMB_MESSAGE_JOB_PATH, parameters: [
-                            [$class: 'StringParameterValue', name: 'MESSAGE_BODY', value: propertiesFileUrl],
-                            [$class: 'StringParameterValue', name: 'TOPIC', value: topic],
-                            [$class: 'StringParameterValue', name: 'EVENT_TYPE', value: eventType]
-                    ]
-                    echo "[SUCCESS] Message was successfully sent."
-                }
-            }
-        }
     }
     post {
         failure {


### PR DESCRIPTION
**Thank you for submitting this pull request**

**JIRA**: https://issues.redhat.com/browse/BXMSPROD-1505

no backport is needed

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest</b> (using <i>this</i> e.g. <b>Jenkins retest this</b> optional but no longer required)
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
