### PR TITLE
build chain updated to v2.6.21

### DIFF
--- a/.ci/actions/build-chain/action.yml
+++ b/.ci/actions/build-chain/action.yml
@@ -23,6 +23,9 @@ inputs:
     description: "The prefix for the annotations title"
     default: ''
     required: false
+  additional-flags:
+    description: "The chance to define additional flags for the execution, as it is done on the CLI side. Just semicolon (;) separated, like '--skipParallelCheckout;--skipExecution;-cct (mvn .*)||$1 -s settings.xml'"
+    required: false
 
 
 runs:
@@ -30,12 +33,13 @@ runs:
   steps:
     - name: Build Chain Tool Execution
       id: build-chain
-      uses: kiegroup/github-action-build-chain@v2.6.20
+      uses: kiegroup/github-action-build-chain@v2.6.21
       with:
         definition-file: ${{ inputs.definition-file }}
         flow-type: ${{ inputs.flow-type }}
         starting-project: ${{ inputs.starting-project }}
         logger-level: ${{ inputs.logger-level }}
         annotations-prefix: ${{ inputs.annotations-prefix }}
+        additional-flags: ${{ inputs.additional-flags }}
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}

--- a/.github/workflows/branch-compilation.yml
+++ b/.github/workflows/branch-compilation.yml
@@ -15,6 +15,14 @@ on:
         description: 'the project to start the job with (it is normally the latest leaf from the tree)'
         required: true
         default: 'kiegroup/kie-wb-distributions'
+      additional-flags:
+        description: 'the additional-flags input. For example "-b main; --fullProjectDependencyTree"'
+        required: true
+        default: ''
+      logger-level:
+        description: 'the logger-level. info by default'
+        required: true
+        default: 'info'
 
 jobs:
   build-chain:
@@ -33,10 +41,12 @@ jobs:
           maven-version: ${{ github.event.inputs.maven-version }}
           cache-key-prefix: ${{ runner.os }}-${{ github.event.inputs.java-version }}-maven${{ github.event.inputs.maven-version }}
       - name: Build Chain
-        uses: ginxo/droolsjbpm-build-bootstrap/.ci/actions/build-chain@compilation
+        uses: kiegroup/droolsjbpm-build-bootstrap/.ci/actions/build-chain@main
         with:
           definition-file: https://raw.githubusercontent.com/kiegroup/droolsjbpm-build-bootstrap/main/.ci/compilation-config.yaml
           starting-project: ${{ github.event.inputs.starting-project }}
           annotations-prefix: ${{ runner.os }}-${{ github.event.inputs.java-version }}/${{ github.event.inputs.maven-version }}
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-          flow-type: branch 
+          flow-type: branch
+          additional-flags: ${{ github.event.inputs.additional-flags }}
+          logger-level:  ${{ github.event.inputs.logger-level }}


### PR DESCRIPTION
**Thank you for submitting this pull request**

* additional-flags
* exports execution summary to spreadsheet

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest</b> (using <i>this</i> e.g. <b>Jenkins retest this</b> optional but no longer required)
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
