### PR TITLE
WIP: RHPAM-4012 add jakarta validation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -314,7 +314,7 @@
     <version.com.google.testing.compile>0.11</version.com.google.testing.compile>
     <version.org.antlr4>4.9.2</version.org.antlr4>
     <!-- CXF's version is aligned with Jetty -->
-    <version.org.apache.cxf>3.3.9</version.org.apache.cxf>
+    <version.org.apache.cxf>3.4.5</version.org.apache.cxf>
     <version.org.apache.camel>2.24.0</version.org.apache.camel>
     <version.org.codehaus.cargo>1.9.3</version.org.codehaus.cargo>
     <version.org.freemarker>2.3.30</version.org.freemarker>

--- a/pom.xml
+++ b/pom.xml
@@ -354,6 +354,7 @@
     <!-- The version greater than 1.0.0.GA is not compatible with GWT 2.8.x -->
     <!-- therefore the property is rewritten in that repository parent -->
     <version.javax.validation>2.0.1.Final</version.javax.validation>
+    <version.jakarta.validation>2.0.2</version.jakarta.validation>
     <version.org.ops4j.pax.url>2.2.0</version.org.ops4j.pax.url>
     <!-- simple-jndi is a small library that helps us avoid JNDI error messages during testing -->
     <version.simple-jndi>0.11.4.1</version.simple-jndi>
@@ -6083,7 +6084,17 @@
         <version>${version.javax.validation}</version>
         <classifier>sources</classifier>
       </dependency>
-
+      <dependency>
+        <groupId>jakarta.validation</groupId>
+        <artifactId>jakarta.validation-api</artifactId>
+        <version>${version.jakarta.validation}</version>
+      </dependency>
+      <dependency>
+        <groupId>jakarta.validation</groupId>
+        <artifactId>jakarta.validation-api</artifactId>
+        <version>${version.jakarta.validation}</version>
+        <classifier>sources</classifier>
+      </dependency>
       <!-- WildFly Core Dependencies missing from ip-bom -->
       <dependency>
         <groupId>org.wildfly</groupId>


### PR DESCRIPTION
**Thank you for submitting this pull request**

**JIRA**: _(please edit the JIRA link if it exists)_ 

[[link](https://www.example.com)](https://issues.redhat.com/browse/RHPAM-4012)

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* https://github.com/kiegroup/kie-soup/pull/243

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest</b> (using <i>this</i> e.g. <b>Jenkins retest this</b> optional but no longer required)
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
