### PR TITLE
BXMSPROD-1601 provide FDB github action for RHBA project

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,8 +27,10 @@ How to retest this PR or trigger a specific build:
 
 * <b>a pull request</b> please add comment: <b>Jenkins retest</b> (using <i>this</i> e.g. <b>Jenkins retest this</b> optional but no longer required)
  
-* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
-  
+* for a <b>full downstream build</b> 
+  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
+  * for <b>github actions</b> job: add the label `run_fdb`
+    
 * <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>
 
 * <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

--- a/.github/workflows/full-downstream.yml
+++ b/.github/workflows/full-downstream.yml
@@ -5,7 +5,6 @@ on:
     types: [labeled]
     branches:
       - main
-      - 8.*
     paths-ignore:
       - 'LICENSE*'
       - '.gitignore'

--- a/.github/workflows/full-downstream.yml
+++ b/.github/workflows/full-downstream.yml
@@ -1,0 +1,53 @@
+name: Build Chain
+
+on:
+  pull_request:
+    types: [labeled]
+    branches:
+      - main
+      - 8.*
+    paths-ignore:
+      - 'LICENSE*'
+      - '.gitignore'
+      - '**.md'
+      - '**.adoc'
+      - '*.txt'
+      - '.ci/**'
+
+jobs:
+  build-chain:
+    if: contains(github.event.pull_request.labels.*.name, 'run_fdb')
+    concurrency:
+      group: fdb-${{ github.head_ref }}
+      cancel-in-progress: true
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        java-version: [11]
+        maven-version: ['3.8.1']
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    name: Full downstream build
+    steps:
+      - name: Clean Disk Space
+        uses: kiegroup/droolsjbpm-build-bootstrap/.ci/actions/ubuntu-disk-space@main
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+      - name: Support long paths
+        if: ${{ matrix.os == 'windows-latest' }}
+        uses: kiegroup/droolsjbpm-build-bootstrap/.ci/actions/long-paths@main
+      - name: Java and Maven Setup
+        uses: kiegroup/droolsjbpm-build-bootstrap/.ci/actions/maven@main
+        with:
+          java-version: ${{ matrix.java-version }}
+          maven-version: ${{ matrix.maven-version }}
+          cache-key-prefix: ${{ runner.os }}-${{ matrix.java-version }}-maven${{ matrix.maven-version }}
+      - name: Build Chain
+        uses: kiegroup/droolsjbpm-build-bootstrap/.ci/actions/build-chain@main
+        with:
+          definition-file: https://raw.githubusercontent.com/kiegroup/droolsjbpm-build-bootstrap/main/.ci/full-downstream-config.yaml
+          annotations-prefix: ${{ runner.os }}-${{ matrix.java-version }}/${{ matrix.maven-version }}
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          flow-type: full-downstream
+      - name: Surefire Report
+        uses: kiegroup/droolsjbpm-build-bootstrap/.ci/actions/surefire-report@main
+        if: ${{ always() }}

--- a/.github/workflows/full-downstream.yml
+++ b/.github/workflows/full-downstream.yml
@@ -9,10 +9,11 @@ on:
     paths-ignore:
       - 'LICENSE*'
       - '.gitignore'
-      - '**.md'
-      - '**.adoc'
+      - '*.md'
       - '*.txt'
-      - '.ci/**'
+      - 'docs/**'
+      - 'ide-configuration/**'
+      - 'script/**'
 
 jobs:
   build-chain:


### PR DESCRIPTION
**Thank you for submitting this pull request**

[BXMSPROD-1601](https://issues.redhat.com/browse/BXMSPROD-1601)

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* https://github.com/kiegroup/kie-soup/pull/245
* https://github.com/kiegroup/droolsjbpm-knowledge/pull/584
* https://github.com/kiegroup/drools/pull/4083
* https://github.com/kiegroup/optaplanner/pull/1745
* https://github.com/kiegroup/lienzo-core/pull/160
* https://github.com/kiegroup/lienzo-tests/pull/133
* https://github.com/kiegroup/appformer/pull/1224
* https://github.com/kiegroup/kie-uberfire-extensions/pull/130
* https://github.com/kiegroup/jbpm/pull/2081
* https://github.com/kiegroup/droolsjbpm-integration/pull/2675
* https://github.com/kiegroup/kie-wb-playground/pull/126
* https://github.com/kiegroup/kie-wb-common/pull/3714
* https://github.com/kiegroup/drools-wb/pull/1530
* https://github.com/kiegroup/jbpm-designer/pull/925
* https://github.com/kiegroup/jbpm-work-items/pull/229
* https://github.com/kiegroup/jbpm-wb/pull/1531
* https://github.com/kiegroup/optaplanner-wb/pull/411
* https://github.com/kiegroup/kie-wb-distributions/pull/1150
* https://github.com/kiegroup/openshift-drools-hacep/pull/126
* https://github.com/kiegroup/process-migration-service/pull/40
* https://github.com/kiegroup/optaweb-employee-rostering/pull/743
* https://github.com/kiegroup/optaweb-vehicle-routing/pull/627
* https://github.com/kiegroup/kie-jpmml-integration/pull/72


<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest</b> (using <i>this</i> e.g. <b>Jenkins retest this</b> optional but no longer required)
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
