### PR TITLE
[RHPAM-4111]-Certify Spring Boot 2.4.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -264,8 +264,7 @@
     <version.org.sonatype.sisu>2.3.0</version.org.sonatype.sisu>
     <version.org.sonatype.sisu.sisu-guice>3.2.3</version.org.sonatype.sisu.sisu-guice>
     <version.org.springframework>5.2.9.RELEASE</version.org.springframework>
-    <version.org.springframework.boot>2.4.9</version.org.springframework.boot>
-    <version.org.springframework.amqpboot>2.3.6.redhat-00004</version.org.springframework.amqpboot>
+    <version.org.springframework.boot>2.4.9</version.org.springframework.boot>    
     <version.org.springframework.osgi>1.2.1</version.org.springframework.osgi>
     <version.org.subethamail>1.2</version.org.subethamail>
     <version.org.subethamail.subethasmtp>3.1.6</version.org.subethamail.subethasmtp>
@@ -2239,12 +2238,6 @@
         <version>${version.org.kie}</version>
         <type>pom</type>
         <scope>import</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>org.amqphub.spring</groupId>
-        <artifactId>amqp-10-jms-spring-boot-starter</artifactId>
-        <version>${version.org.springframework.amqpboot}</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -263,7 +263,7 @@
     <version.org.sonatype.plexus.plexus-sec-dispatcher>1.3</version.org.sonatype.plexus.plexus-sec-dispatcher>
     <version.org.sonatype.sisu>2.3.0</version.org.sonatype.sisu>
     <version.org.sonatype.sisu.sisu-guice>3.2.3</version.org.sonatype.sisu.sisu-guice>
-    <version.org.springframework>5.2.9.RELEASE</version.org.springframework>
+    <version.org.springframework>5.3.14</version.org.springframework>
     <version.org.springframework.boot>2.4.9</version.org.springframework.boot>    
     <version.org.springframework.osgi>1.2.1</version.org.springframework.osgi>
     <version.org.subethamail>1.2</version.org.subethamail>

--- a/pom.xml
+++ b/pom.xml
@@ -264,8 +264,8 @@
     <version.org.sonatype.sisu>2.3.0</version.org.sonatype.sisu>
     <version.org.sonatype.sisu.sisu-guice>3.2.3</version.org.sonatype.sisu.sisu-guice>
     <version.org.springframework>5.2.9.RELEASE</version.org.springframework>
-    <version.org.springframework.boot>2.3.4.RELEASE</version.org.springframework.boot>
-    <version.org.springframework.amqpboot>2.3.4</version.org.springframework.amqpboot>
+    <version.org.springframework.boot>2.4.9</version.org.springframework.boot>
+    <version.org.springframework.amqpboot>2.3.6.redhat-00004</version.org.springframework.amqpboot>
     <version.org.springframework.osgi>1.2.1</version.org.springframework.osgi>
     <version.org.subethamail>1.2</version.org.subethamail>
     <version.org.subethamail.subethasmtp>3.1.6</version.org.subethamail.subethasmtp>


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/RHPAM-4111
Upgraded version of Spring Boot dependencies to align with Red Hat supported Spring Boot 2.4.9 version.
This PR should be merged along with a related PR- https://github.com/kiegroup/droolsjbpm-integration/pull/2680