### PR TITLE
Updated awaitility version to 4.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -193,7 +193,7 @@
     <version.org.hornetq>2.4.7.Final</version.org.hornetq>
     <version.org.infinispan>11.0.9.Final</version.org.infinispan>
     <!--This needs to be in sync with JUnit-->
-    <version.org.hamcrest>1.3</version.org.hamcrest>
+    <version.org.hamcrest>2.1</version.org.hamcrest>
     <version.org.hsqldb>2.3.0</version.org.hsqldb>
     <version.org.jasypt.jasypt>1.9.2</version.org.jasypt.jasypt>
     <version.org.javassist>3.26.0-GA</version.org.javassist>

--- a/pom.xml
+++ b/pom.xml
@@ -477,7 +477,7 @@
     <version.npm>7.15.1</version.npm>
     <version.yarn>v1.22.4</version.yarn>
 
-    <version.org.awaitility>3.0.0</version.org.awaitility>
+    <version.org.awaitility>4.1.0</version.org.awaitility>
     <version.io.github.bonigarcia>3.8.1</version.io.github.bonigarcia>
 
     <version.org.kogito.gwt-jsonix-schema-compiler>1.2.1</version.org.kogito.gwt-jsonix-schema-compiler>


### PR DESCRIPTION
This update is required to perform the backport on drools of  the pull request [4147](https://github.com/kiegroup/drools/pull/4147)