### PR TITLE
DROOLS-6879 : Update to Wildfly core 17.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -274,7 +274,7 @@
     <version.org.wildfly>23.0.2.Final</version.org.wildfly>
     <version.org.wildfly.arquillian>3.0.1.Final</version.org.wildfly.arquillian>
     <version.org.wildfly.client>1.0.1.Final</version.org.wildfly.client>
-    <version.org.wildfly.core>15.0.1.Final</version.org.wildfly.core>
+    <version.org.wildfly.core>17.0.0.Final</version.org.wildfly.core>
     <version.org.wildfly.common>1.5.4.Final</version.org.wildfly.common>
     <version.org.yaml.snakeyaml>1.26</version.org.yaml.snakeyaml>
     <version.org.mozilla.rhino>1.7.13</version.org.mozilla.rhino>


### PR DESCRIPTION
[DROOLS-6879](https://issues.redhat.com/browse/DROOLS-6879)


Testing if FDB passes with the 17.0.0 Wildfly.

- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1918
- https://github.com/kiegroup/appformer/pull/1249
- 
<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest</b> (using <i>this</i> e.g. <b>Jenkins retest this</b> optional but no longer required)
 
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
    
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
