### PR TITLE
kiegroup status webpage

### DIFF
--- a/.ci/chain-status-info.md
+++ b/.ci/chain-status-info.md
@@ -1,0 +1,5 @@
+# Kiegroup organization repositories CI Status
+
+This project is based on [chain-status](https://github.com/kiegroup/chain-status) and information generated thanks to [build-chain-configuration-reader](https://github.com/kiegroup/build-chain-configuration-reader) using [droolsjbpm-build-bootstrap definition file](https://github.com/kiegroup/droolsjbpm-build-bootstrap/blob/main/.ci/pull-request-config.yaml).
+
+Due to the retrieved information requires a `GITHUB_TOKEN` and github API has a limitation it is better to not collect the information on every request from this webpage is made. So this webpage does not really requires an application service and all the required data is stored in github pages. This information is normally retrieved, treated and stored using [chain-status/action tool](https://github.com/kiegroup/chain-status/tree/main/packages/action) which is exposed as a Github Action tool, so we can customize the job execution frequency as we need.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,6 +10,8 @@
 * link 2
 * link 3 etc.
 
+You can check RHBA CI status from [Chain Status webpage](https://kiegroup.github.io/droolsjbpm-build-bootstrap/)
+
 <details>
 <summary>
 How to replicate CI configuration locally?

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,7 +10,7 @@
 * link 2
 * link 3 etc.
 
-You can check RHBA CI status from [Chain Status webpage](https://kiegroup.github.io/droolsjbpm-build-bootstrap/)
+You can check Kiegroup organization repositories CI status from [Chain Status webpage](https://kiegroup.github.io/droolsjbpm-build-bootstrap/)
 
 <details>
 <summary>

--- a/.github/workflows/generate_status_page.yaml
+++ b/.github/workflows/generate_status_page.yaml
@@ -17,5 +17,6 @@ jobs:
       - name: Generate status page
         uses: kiegroup/chain-status/.ci/actions/generate-app@main
         with:
+          info-md-url: "https://raw.githubusercontent.com/kiegroup/droolsjbpm-build-bootstrap/main/.ci/chain-status-info.md"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/generate_status_page.yaml
+++ b/.github/workflows/generate_status_page.yaml
@@ -1,0 +1,21 @@
+name: Generate status page
+
+on: workflow_dispatch
+
+jobs:
+  generate-status-page:
+    concurrency:
+      group: generate-status-page
+      cancel-in-progress: true
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+      fail-fast: true
+    runs-on: ubuntu-latest
+    name: Generate status page
+    steps:
+      - name: Generate status page
+        uses: kiegroup/chain-status/.ci/actions/generate-app@main
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+

--- a/.github/workflows/generate_status_page_data.yaml
+++ b/.github/workflows/generate_status_page_data.yaml
@@ -1,0 +1,30 @@
+name: Generate status page data
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 * * * *'
+jobs:
+  generate-status-page-data:
+    concurrency:
+      group: generate-status-page-data
+      cancel-in-progress: true
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+      fail-fast: true
+    runs-on: ubuntu-latest
+    name: Generate status page data
+    steps:
+      - name: Generate status page data
+        uses: kiegroup/chain-status/.ci/actions/generate-data@main
+        with:
+          definition-file: https://raw.githubusercontent.com/kiegroup/droolsjbpm-build-bootstrap/main/.ci/pull-request-config.yaml
+          title: RHBA Status
+          subtitle: Contribution Status
+          base-branch-filter: main,7.59.x
+          created-by: Github Action
+          created-url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          logger-level: debug
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+

--- a/.github/workflows/generate_status_page_data.yaml
+++ b/.github/workflows/generate_status_page_data.yaml
@@ -20,8 +20,8 @@ jobs:
         uses: kiegroup/chain-status/.ci/actions/generate-data@main
         with:
           definition-file: https://raw.githubusercontent.com/kiegroup/droolsjbpm-build-bootstrap/main/.ci/pull-request-config.yaml
-          title: RHBA Status
-          subtitle: Contribution Status
+          title: Kiegroup Status
+          subtitle: Kiegroup organization repositories CI Status
           base-branch-filter: main,7.59.x
           created-by: Github Action
           created-url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/README.md
+++ b/README.md
@@ -648,6 +648,7 @@ CI Information
 ==================
 
 See [CI Information document](.ci)
+You can check RHBA CI status from [Chain Status webpage](https://kiegroup.github.io/droolsjbpm-build-bootstrap/)
 
 Team communication
 ==================


### PR DESCRIPTION
The idea is to generate a webpage like https://ginxo.github.io/droolsjbpm-build-bootstrap

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest</b> (using <i>this</i> e.g. <b>Jenkins retest this</b> optional but no longer required)
 
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
    
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
