### PR TITLE
fixed binaries to upload to filemgmt.jboss.org

### DIFF
--- a/.ci/jenkins/Jenkinsfile.release
+++ b/.ci/jenkins/Jenkinsfile.release
@@ -181,6 +181,32 @@ pipeline {
                 LOG: attached""", subject: "community-release ${kieVersion} failed", to: "bsig@redhat.com", attachLog:true
             }
         }
+         // create a local directory for archiving artifacts
+         stage('Create upload dir') {
+             when{
+                 expression { repBuild == 'YES'}
+             }
+             steps {
+                 script {
+                     execute {
+                         // creates a directory ${kieVersion}"_uploadBinaries with binaries for the web-pages
+                         sh './droolsjbpm-build-bootstrap/script/release/prepareUploadDir.sh'
+                     }
+                 }
+             }
+         }
+         // the directory of ${kieVersion}"_uploadBinaries will be compressed
+         stage('tar.gz uploadDir & archive artifacts'){
+             when{
+                 expression { repBuild == 'YES'}
+             }
+             steps {
+                 sh 'tar -czvf "${kieVersion}"_uploadBinaries.tar.gz "${kieVersion}"_uploadBinaries'
+                 archiveArtifacts '*.tar.gz'
+                 // removal of *.tar.gz file to save disk space
+                 sh "rm -rf ${kieVersion}_binaries.tar.gz"
+             }
+         }
         stage('Publish JUnit test results reports') {
             when{
                 expression { reBuild == 'YES'}
@@ -189,17 +215,6 @@ pipeline {
                 execute {
                     junit '**/target/*-reports/TEST-*.xml'
                 }
-            }
-        }
-        stage('tar.gz deployed binaries'){
-            when{
-                expression { reBuild == 'YES'}
-            }
-            steps {
-                sh "tar -czvf ${kieVersion}_binaries.tar.gz community-deploy-dir"
-                archiveArtifacts '*.tar.gz'
-                // remove file to save disk space
-                sh "rm -rf ${kieVersion}_binaries.tar.gz"
             }
         }
         // binaries will be compressed and uploaded to Nexus

--- a/.ci/release-config.yaml
+++ b/.ci/release-config.yaml
@@ -11,8 +11,14 @@ default:
       ${{ env.MAVEN_COMMAND }}
       ${{ env.WORKSPACE }}/clean-up.sh `pwd`
 build:
+  - project: kiegroup/jbpm-work-items
+      ${{ env.MAVEN_COMMAND }}
+  - project: kiegroup/optaplanner
+      ${{ env.MAVEN_COMMAND }}
   - project: kiegroup/optaweb-employee-rostering
     skip: true
   - project: kiegroup/optaweb-vehicle-routing
     skip: true
+  - project: kiegroup/kie-docs
+      ${{ env.MAVEN_COMMAND }}
 


### PR DESCRIPTION
**Thank you for submitting this pull request**

- for three projects (optaplanner, kie-docs and jbpm-work-items) can't be removed the `/target` directories after building because there are binaries needed for the upload to file.mgmt.jboss.org (web pages)
- the binaries to upload to filemgmt.jboss.org have to be archived  in case they are needed again in a second pipeline run if the fist pipeline was aborted or failed. This the whole build doesn't to have be repeated.
- once the *tar.gz file was archived it will be removed to save disk space


You can check Kiegroup organization repositories CI status from [Chain Status webpage](https://kiegroup.github.io/droolsjbpm-build-bootstrap/)

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest</b> (using <i>this</i> e.g. <b>Jenkins retest this</b> optional but no longer required)
 
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
    
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
