### PR TITLE
removed when condition

### DIFF
--- a/.ci/jenkins/Jenkinsfile.release
+++ b/.ci/jenkins/Jenkinsfile.release
@@ -96,9 +96,6 @@ pipeline {
             }
         }
         stage('Install build-chain tool') {
-            when{
-                expression { reBuild == 'YES'}
-            }
             steps {
                 script {
                     println "[INFO] Getting build-chain version from composite action file"
@@ -204,7 +201,7 @@ pipeline {
                  sh 'tar -czvf "${kieVersion}"_uploadBinaries.tar.gz "${kieVersion}"_uploadBinaries'
                  archiveArtifacts '*.tar.gz'
                  // removal of *.tar.gz file to save disk space
-                 sh "rm -rf *_binaries.tar.gz"
+                 sh "rm -rf *_uploadBinaries.tar.gz"
              }
          }
         stage('Publish JUnit test results reports') {
@@ -434,7 +431,7 @@ pipeline {
                     projectName: '${JOB_NAME}',
                     selector: [$class: 'SpecificBuildSelector', buildNumber: "$buildNr"]
                 ])
-                sh 'tar -xzvf "${kieVersion}"_binaries.tar.gz \n' +
+                sh 'tar -xzvf *_uploadBinaries.tar.gz \n' +
                    'ls -al'
             }
         }

--- a/script/release/09_createjBPM_installers.sh
+++ b/script/release/09_createjBPM_installers.sh
@@ -5,7 +5,7 @@
 toolsVer=$1
 
 # fetch the <version.org.kie> from kie-parent-metadata pom.xml and set it on parameter KIE_VERSION
-kieVersion=$(sed -e 's/^[ \t]*//' -e 's/[ \t]*$//' -n -e 's/<version.org.kie>\(.*\)<\/version.org.kie>/\1/p' droolsjbpm-build-bootstrap/pom.xml)
+kieVersion=$(sed -e 's/^[ \t]*//' -e 's/[ \t]*$//' -n -e 's/<version.org.kie>\(.*\)<\/version.org.kie>/\1/p' bc/kiegroup_droolsjbpm_build_bootstrap/pom.xml)
 
 URLgroup="public-jboss"
 

--- a/script/release/10a_drools_upload_filemgmt.sh
+++ b/script/release/10a_drools_upload_filemgmt.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 # fetch the <version.org.kie> from kie-parent-metadata pom.xml and set it on parameter KIE_VERSION
-kieVersion=$(sed -e 's/^[ \t]*//' -e 's/[ \t]*$//' -n -e 's/<version.org.kie>\(.*\)<\/version.org.kie>/\1/p' droolsjbpm-build-bootstrap/pom.xml)
+kieVersion=$(sed -e 's/^[ \t]*//' -e 's/[ \t]*$//' -n -e 's/<version.org.kie>\(.*\)<\/version.org.kie>/\1/p' bc/kiegroup_droolsjbpm_build_bootstrap/pom.xml)
 
 filemgmtServer=drools@filemgmt-prod.jboss.org
 rsync_filemgmt=drools@filemgmt-prod-sync.jboss.org
@@ -11,8 +11,8 @@ uploadDir=${kieVersion}_uploadBinaries
 
 # create directory on filemgmt-prod.jboss.org for new release
 touch create_version
-echo "mkdir ${droolsDocs}/${$kieVersion}" > create_version
-echo "mkdir ${droolsHtdocs}/${$kieVersion}" >> create_version
+echo "mkdir ${droolsDocs}/${kieVersion}" > create_version
+echo "mkdir ${droolsHtdocs}/${kieVersion}" >> create_version
 chmod +x create_version
 sftp -b create_version $filemgmtServer
 
@@ -38,12 +38,10 @@ echo "put ${uploadDir}/business-central-${kieVersion}-*.war ${droolsHtdocs}/${ki
 echo "put ${uploadDir}/kie-server-distribution-${kieVersion}.zip ${droolsHtdocs}/${kieVersion}" >> upload_binaries
 chmod +x upload_binaries
 sftp -b upload_binaries $filemgmtServer
+
 # upload docs to filemgmt-prod.jboss.org
-touch upload_docs
-echo "put ${uploadDir}/drools-docs/* ${droolsDocs}/${kieVersion}/drools-docs" > upload_docs
-echo "put ${uploadDir}/kie-api-javadoc/* ${droolsDocs}/${kieVersion}/kie-api-javadoc" >> upload_docs
-chmod +x upload_docs
-sftp -b upload_docs $filemgmtServer
+rsync -Pavqr -e 'ssh -p 2222' --protocol=28 --delete-after ${uploadDir}/drools-docs/* ${rsync_filemgmt}:${droolsDocs}/${kieVersion}/drools-docs
+rsync -Pavqr -e 'ssh -p 2222' --protocol=28 --delete-after ${uploadDir}/kie-api-javadoc/* ${rsync_filemgmt}:${droolsDocs}/${kieVersion}kie-api-javadoc
 
 
 # make filemgmt symbolic links for drools
@@ -75,5 +73,4 @@ cd ..
 rm -rf create_version
 rm -rf create_*_dir
 rm -rf upload_binaries
-rm -rf upload_docs
 rm -rf filemgmt_links

--- a/script/release/10c_optaplanner_upload_filemgmt.sh
+++ b/script/release/10c_optaplanner_upload_filemgmt.sh
@@ -1,9 +1,10 @@
 #!/bin/bash -e
 
 # fetch the <version.org.kie> from kie-parent-metadata pom.xml and set it on parameter KIE_VERSION
-kieVersion=$(sed -e 's/^[ \t]*//' -e 's/[ \t]*$//' -n -e 's/<version.org.kie>\(.*\)<\/version.org.kie>/\1/p' droolsjbpm-build-bootstrap/pom.xml)
+kieVersion=$(sed -e 's/^[ \t]*//' -e 's/[ \t]*$//' -n -e 's/<version.org.kie>\(.*\)<\/version.org.kie>/\1/p' bc/kiegroup_droolsjbpm_build_bootstrap/pom.xml)
 
 filemgmtServer=optaplanner@filemgmt-prod.jboss.org
+rsync_filemgmt=optaplanner@filemgmt-prod-sync.jboss.org
 optaplannerDocs=docs_htdocs/optaplanner/release
 optaplannerHtdocs=downloads_htdocs/optaplanner/release
 uploadDir=${kieVersion}_uploadBinaries
@@ -38,17 +39,14 @@ touch upload_binaries
 echo "put ${uploadDir}/optaplanner-distribution-${kieVersion}.zip ${optaplannerHtdocs}/${kieVersion}" > upload_binaries
 chmod +x upload_binaries
 sftp -b upload_binaries $filemgmtServer
+
 # upload docs to filemgmt-prod.jboss.org
-touch upload_docs
-echo "put ${uploadDir}/optaplanner-docs/* ${optaplannerDocs}/${kieVersion}/optaplanner-docs" > upload_docs
-echo "put ${uploadDir}/optaplanner-javadoc/* ${optaplannerDocs}/${kieVersion}/optaplanner-javadoc" >> upload_docs
-echo "put ${uploadDir}/optaplanner-wb-es-docs/* ${optaplannerDocs}/${kieVersion}/optaplanner-wb-es-docs" >> upload_docs
-chmod +x upload_docs
-sftp -b upload_docs $filemgmtServer
+rsync -Pavqr -e 'ssh -p 2222' --protocol=28 --delete-after ${uploadDir}/optaplanner-docs/* ${rsync_filemgmt}:${optaplannerDocs}/${kieVersion}/optaplanner-docs
+rsync -Pavqr -e 'ssh -p 2222' --protocol=28 --delete-after ${uploadDir}/optaplanner-javadoc/* ${rsync_filemgmt}:${optaplannerDocs}/${kieVersion}/optaplanner-javadoc
+rsync -Pavqr -e 'ssh -p 2222' --protocol=28 --delete-after ${uploadDir}/optaplanner-wb-es-docs/* ${rsync_filemgmt}:${optaplannerDocs}/${kieVersion}/optaplanner-wb-es-docs
 
 # remove files for uploading optaplanner
 rm -rf upload_binaries
-rm -rf upload_docs
 rm -rf create_*_dir
 rm -rf create_version
 


### PR DESCRIPTION
**Thank you for submitting this pull request**

The build chain tool should be installed in any case, also when a new build isn't needed. For pushing the tags the build-chain tools is needed too.

**JIRA**: _(please edit the JIRA link if it exists)_ 

[link](https://www.example.com)

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* paste the link(s) from GitHub here
* link 2
* link 3 etc.

You can check Kiegroup organization repositories CI status from [Chain Status webpage](https://kiegroup.github.io/droolsjbpm-build-bootstrap/)

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest</b> (using <i>this</i> e.g. <b>Jenkins retest this</b> optional but no longer required)
 
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
    
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
