### PR TITLE
fixes for release pipeline

### DIFF
--- a/.ci/jenkins/Jenkinsfile.release
+++ b/.ci/jenkins/Jenkinsfile.release
@@ -164,6 +164,16 @@ pipeline {
                 }
             }
         }
+        stage('Publish JUnit test results reports') {
+            when{
+                expression { runBuild == 'YES'}
+            }
+            steps {
+                execute {
+                    junit '**/target/*-reports/TEST-*.xml'
+                }
+            }
+        }
         //send mail if build fails
         stage('send mail only if build fails'){
             when{
@@ -198,22 +208,15 @@ pipeline {
                  expression { runBuild == 'YES'}
              }
              steps {
-                 sh "tar -czvf ${kieVersion}_uploadBinaries.tar.gz ${kieVersion}_uploadBinaries"
-                 archiveArtifacts '*.tar.gz'
-                 // removal of *.tar.gz file to save disk space
-                 sh "rm -rf *_uploadBinaries.tar.gz"
+                script {
+                    execute {
+                        sh "tar -czvf ${kieVersion}_uploadBinaries.tar.gz ${kieVersion}_uploadBinaries"
+                        archiveArtifacts '*.tar.gz'
+                        sh "rm -rf ${kieVersion}_uploadBinaries.tar.gz"
+                    }
+                }
              }
          }
-        stage('Publish JUnit test results reports') {
-            when{
-                expression { runBuild == 'YES'}
-            }
-            steps {
-                execute {
-                    junit '**/target/*-reports/TEST-*.xml'
-                }
-            }
-        }
         // binaries will be compressed and uploaded to Nexus
         stage('Upload binaries to staging repository on Nexus') {
             when{
@@ -235,70 +238,6 @@ pipeline {
                 }
             }
         }
-        stage('CURLS for sanity checks and additional kie tests'){
-            when{
-                expression { runBuild == 'YES'}
-            }
-            steps{
-            sleep(time:10,unit:"MINUTES")
-                script{
-                    execute {
-                        def repositories='kie-group'
-                        def suffixList=['kie-wb-distributions', 'business-central', 'business-central-webapp', 'business-monitoring-webapp', 'jbpm-server-distribution']
-                        suffixList.each{ suffix ->
-                            def artefacts=sh(returnStdout: true, script:"curl https://origin-repository.jboss.org/nexus/content/groups/$repositories/org/kie/$suffix/$kieVersion/ | grep href=.*$suffix | sed 's/^.*$suffix.*\">//p' | sed 's/<\\/a><\\/td>//p'| uniq").split("\\r?\\n")
-                            artefacts.each { println it }
-                            artefacts.each { artefact ->
-                                sh "curl --head https://proxy01-repository.jboss.org/nexus/content/groups/$repositories/org/kie/$suffix/$kieVersion/$artefact"
-                                sh "curl --head https://proxy02-repository.jboss.org/nexus/content/groups/$repositories/org/kie/$suffix/$kieVersion/$artefact"
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        stage('Curls for additional drools tests'){
-            when{
-                expression { runBuild == 'YES'}
-            }
-            steps{
-                script{
-                    execute {
-                        def repositories='kie-group'
-                        def suffixList=['droolsjbpm-integration']
-                        suffixList.each{ suffix ->
-                            def artefacts=sh(returnStdout: true, script:"curl https://origin-repository.jboss.org/nexus/content/groups/$repositories/org/drools/$suffix/$kieVersion/ | grep href=.*$suffix | sed 's/^.*$suffix.*\">//p' | sed 's/<\\/a>.*//p' | uniq").split("\\r?\\n")
-                            artefacts.each { println it }
-                            artefacts.each { artefact ->
-                                sh "curl --head https://proxy01-repository.jboss.org/nexus/content/groups/$repositories/org/drools/$suffix/$kieVersion/$artefact"
-                                sh "curl --head https://proxy02-repository.jboss.org/nexus/content/groups/$repositories/org/drools/$suffix/$kieVersion/$artefact"
-                            }
-                        }
-                    }
-                }
-            }
-        }
-         stage('Curls for additional jbpm tests'){
-            when{
-                expression { runBuild == 'YES'}
-            }
-             steps{
-                 script{
-                    execute {
-                        def repositories='kie-group'
-                        def suffixList=['jbpm']
-                        suffixList.each{ suffix ->
-                            def artefacts=sh(returnStdout: true, script:"curl https://origin-repository.jboss.org/nexus/content/groups/$repositories/org/jbpm/$suffix/$kieVersion/ | grep href=.*$suffix | sed 's/^.*$suffix.*\">//p' | sed 's/<\\/a>.*//p' | uniq").split("\\r?\\n")
-                            artefacts.each { println it }
-                            artefacts.each { artefact ->
-                                sh "curl --head https://proxy01-repository.jboss.org/nexus/content/groups/$repositories/org/jbpm/$suffix/$kieVersion/$artefact"
-                                sh "curl --head https://proxy02-repository.jboss.org/nexus/content/groups/$repositories/org/jbpm/$suffix/$kieVersion/$artefact"
-                            }
-                        }
-                    }
-                 }
-             }
-         }
          stage('Additional tests for community') {
              when{
                  expression { runBuild == 'YES'}
@@ -359,26 +298,6 @@ pipeline {
                         def buildChainActionInfo = [action: 'branch', file: 'create-push-tags.yaml']
                         withCredentials([string(credentialsId: 'kie-ci1-token', variable: 'GITHUB_TOKEN')]) {
                             sh "build-chain-action -token=${GITHUB_TOKEN} -df='https://raw.githubusercontent.com/${buildChainGroup}/droolsjbpm-build-bootstrap/${buildChainBranch}/.ci/${buildChainActionInfo.file}' -folder='bc' build ${buildChainActionInfo.action} -sp='${buildChainGroup}/droolsjbpm-build-bootstrap' -b='${env.CHECKOUT_BRANCH}' --fullProjectDependencyTree --skipParallelCheckout"
-                        }
-                    }
-                }
-            }
-        }
-        // load URL for repositories.jboss.org to prevent using origin-repositories.jboss.org
-        stage('CURLS for released binaries'){
-            steps{
-                sleep(time:3,unit:"MINUTES")
-                script{
-                    excute {
-                        def repositories = 'public-jboss'
-                        def suffixList=['kie-wb-distributions', 'business-central', 'business-central-webapp', 'business-monitoring-webapp', 'jbpm-server-distribution']
-                        suffixList.each{ suffix ->
-                            def artefacts = sh(returnStdout: true, script:"curl https://origin-repository.jboss.org/nexus/content/groups/$repositories/org/kie/$suffix/$kieVersion/ | grep href=.*$suffix | sed 's/^.*$suffix.*\">//p' | sed 's/<\\/a>.*//p' | uniq").split("\\r?\\n")
-                            artefacts.each { println it }
-                            artefacts.each { artefact ->
-                                sh "curl --head https://proxy01-repository.jboss.org/nexus/content/groups/$repositories/org/kie/$suffix/$kieVersion/$artefact"
-                                sh "curl --head https://proxy02-repository.jboss.org/nexus/content/groups/$repositories/org/kie/$suffix/$kieVersion/$artefact"
-                            }
                         }
                     }
                 }


### PR DESCRIPTION
**Thank you for submitting this pull request**

Basically these fixes include:
- the order of junit - this happens directly after the build, so when the pìpeline is halted in a later step the junits are done
- the zipping and archiving of binaries is integrated in a script and execute { - so in case it fails it can repeated
- all curls to proxy01 and proxy02 were removed since they don't exist anymore. The caching is done by Akamai.  

You can check Kiegroup organization repositories CI status from [Chain Status webpage](https://kiegroup.github.io/droolsjbpm-build-bootstrap/)

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest</b> (using <i>this</i> e.g. <b>Jenkins retest this</b> optional but no longer required)
 
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
    
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
