### PR TITLE
Jenkinsfile.nightly adapted to 7.67.x-blue properties

### DIFF
--- a/.ci/jenkins/Jenkinsfile.nightly
+++ b/.ci/jenkins/Jenkinsfile.nightly
@@ -90,7 +90,8 @@ pipeline {
                         [$class: 'StringParameterValue', name: 'TIME_STAMP', value: "${PME_BUILD_VARIABLES['datetimeSuffix']}"],
                         [$class: 'StringParameterValue', name: 'MVEL_VERSION', value: PME_BUILD_VARIABLES['mvelVersion']],
                         [$class: 'StringParameterValue', name: 'IZPACK_VERSION', value: PME_BUILD_VARIABLES['izpackVersion']],
-                        [$class: 'StringParameterValue', name: 'INSTALLER_COMMONS_VERSION', value: PME_BUILD_VARIABLES['installerCommonsVersion']]
+                        [$class: 'StringParameterValue', name: 'INSTALLER_COMMONS_VERSION', value: PME_BUILD_VARIABLES['installerCommonsVersion']],
+                        [$class: 'StringParameterValue', name: 'NIGHTLY_FILE_ID', value: 'bamoe-nightly-properties-template']
                     ]
                 }
             }


### PR DESCRIPTION
**Thank you for submitting this pull request**

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* 

You can check Kiegroup organization repositories CI status from [Chain Status webpage](https://kiegroup.github.io/droolsjbpm-build-bootstrap/)

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest</b> (using <i>this</i> e.g. <b>Jenkins retest this</b> optional but no longer required)
 
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
    
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
