### PR TITLE
partial upload to Nexus

### DIFF
--- a/.ci/jenkins/Jenkinsfile.release
+++ b/.ci/jenkins/Jenkinsfile.release
@@ -188,78 +188,82 @@ pipeline {
                 LOG: attached""", subject: "community-release ${kieVersion} failed", to: "bsig@redhat.com", attachLog:true
             }
         }
-         // create a local directory for archiving artifacts
-         stage('Create upload dir') {
-             when{
-                 expression { runBuild == 'YES'}
-             }
-             steps {
-                 script {
-                     execute {
-                         // creates a directory ${kieVersion}"_uploadBinaries with binaries for the web-pages
-                         sh './script/release/prepareUploadDir.sh'
-                     }
-                 }
-             }
-         }
-         // the directory of ${kieVersion}_uploadBinaries will be compressed
-         stage('tar.gz uploadDir & archive artifacts'){
-             when{
-                 expression { runBuild == 'YES'}
-             }
-             steps {
-                script {
-                    execute {
-                        sh "tar -czvf ${kieVersion}_uploadBinaries.tar.gz ${kieVersion}_uploadBinaries"
-                        archiveArtifacts '*.tar.gz'
-                        sh "rm -rf ${kieVersion}_uploadBinaries.tar.gz"
-                    }
-                }
-             }
-         }
-        // binaries will be compressed and uploaded to Nexus
-        stage('Upload binaries to staging repository on Nexus') {
+        // create a local directory for archiving artifacts
+        stage('Create upload dir') {
             when{
                 expression { runBuild == 'YES'}
             }
             steps {
                 script {
                     execute {
-                        withCredentials([usernameColonPassword(credentialsId: 'kie_upload_Nexus', variable: 'CREDS')]) {
-                            sh """
-                                cd $zipDir
-                                zip -qr kiegroup .
-                                repoID=\$(curl --header 'Content-Type: application/xml' -X POST -u $CREDS --data "<promoteRequest><data><description>kie-${kieVersion}</description></data></promoteRequest>" -v https://repository.jboss.org/nexus/service/local/staging/profiles/15c58a1abc895b/start -H "Connection: close" | grep -oP '(?<=stagedRepositoryId>).*[0-9]')
-                                curl --silent --upload-file kiegroup.zip -u \$CREDS -v https://repository.jboss.org/nexus/service/local/repositories/\$repoID/content-compressed -H "Connection: close"
-                                curl --header "Content-Type: application/xml" -X POST -u \$CREDS --data "<promoteRequest><data><stagedRepositoryId>\${repoID}</stagedRepositoryId><description>kie-${kieVersion}</description></data></promoteRequest>" -v https://repository.jboss.org/nexus/service/local/staging/profiles/15c58a1abc895b/finish -H "Connection: close"
-                                """
+                        // creates a directory ${kieVersion}"_uploadBinaries with binaries for the web-pages
+                        sh './script/release/prepareUploadDir.sh'
+                    }
+                }
+            }
+        }
+        // the directory of ${kieVersion}_uploadBinaries will be compressed
+        stage('tar.gz uploadDir & archive artifacts'){
+            when{
+                expression { runBuild == 'YES'}
+            }
+            steps {
+               script {
+                   execute {
+                       sh "tar -czvf ${kieVersion}_uploadBinaries.tar.gz ${kieVersion}_uploadBinaries"
+                       archiveArtifacts '*.tar.gz'
+                       sh "rm -rf ${kieVersion}_uploadBinaries.tar.gz"
+                   }
+               }
+            }
+        }
+        // binaries will be compressed and uploaded to Nexus
+        stage('Upload binaries to staging repository on Nexus') {
+            when{
+                expression { runBuild == 'YES'}
+            }
+            steps {
+                execute {
+                    withCredentials([usernameColonPassword(credentialsId: 'kie_upload_Nexus', variable: 'CREDS')]) {
+                        dir("$WORKSPACE/${zipDir}"){
+                            script {
+                                env.repoID = sh(script: """curl --header 'Content-Type: application/xml' -X POST -u $CREDS --data "<promoteRequest><data><description>kie-${kieVersion}</description></data></promoteRequest>" -v https://repository.jboss.org/nexus/service/local/staging/profiles/15c58a1abc895b/start -H "Connection: close" | grep -oP '(?<=stagedRepositoryId>).*[0-9]' """, returnStdout: true).trim()
+                                echo "repoID: ${repoID}"
+                                def repositories=['dashbuilder', 'drools', 'jbpm', 'uberfire', 'optaplanner']
+                                repositories.each{ repo ->
+                                    sh "zip -qr ${repo}.zip org/${repo}"
+                                    sh """curl --silent --upload-file ${repo}.zip -u \$CREDS -v https://repository.jboss.org/nexus/service/local/repositories/\$repoID/content-compressed -H "Connection: keep-alive" -H "Keep-Alive: timeout=1800000, max=0" """
+                                }
+                                sh "sh $WORKSPACE/script/release/12_splitOrgKie.sh"
+                                sh """curl --header "Content-Type: application/xml" -X POST -u \$CREDS --data "<promoteRequest><data><stagedRepositoryId>${repoID}</stagedRepositoryId><description>kie-${kieVersion}</description></data></promoteRequest>" -v https://repository.jboss.org/nexus/service/local/staging/profiles/15c58a1abc895b/finish -H "Connection: close" """
+                            }
                         }
                     }
                 }
             }
         }
-         stage('Additional tests for community') {
-             when{
-                 expression { runBuild == 'YES'}
-             }
-             parallel{
-                stage('jbpmTestCoverageMatrix'){
-                    steps{
-                        build job: "jbpmTestCoverageMatrix", propagate: false, parameters: [[$class: 'StringParameterValue', name: 'kieVersion', value: kieVersion]]
-                    }
-                }
-                stage('kieWbTestMatrix'){
-                    steps{
-                        build job: "kieWbTestMatrix", propagate: false, parameters: [[$class: 'StringParameterValue', name: 'kieVersion', value: kieVersion]]
-                    }
-                }
-                stage('kieServerMatrix'){
-                    steps{
-                        build job: "kieServerMatrix", propagate: false, parameters: [[$class: 'StringParameterValue', name: 'kieVersion', value: kieVersion]]
-                    }
-                }
-             }
-         }
+        stage('Additional tests for community') {
+            when{
+                expression { runBuild == 'YES'}
+            }
+            parallel{
+               stage('jbpmTestCoverageMatrix'){
+                   steps{
+                       build job: "jbpmTestCoverageMatrix", propagate: false, parameters: [[$class: 'StringParameterValue', name: 'kieVersion', value: kieVersion]]
+                   }
+               }
+               stage('kieWbTestMatrix'){
+                   steps{
+                       build job: "kieWbTestMatrix", propagate: false, parameters: [[$class: 'StringParameterValue', name: 'kieVersion', value: kieVersion]]
+                   }
+               }
+               stage('kieServerMatrix'){
+                   steps{
+                       build job: "kieServerMatrix", propagate: false, parameters: [[$class: 'StringParameterValue', name: 'kieVersion', value: kieVersion]]
+                   }
+               }
+            }
+        }
         // send email for Sanity Checks
         stage('send email with build result'){
             when{

--- a/script/release/12_splitOrgKie.sh
+++ b/script/release/12_splitOrgKie.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -ex
+input_dir='org/kie'
+imax=25
+array_list=( $(ls $input_dir) )
+echo "( ${array_list[@]} )"
+ndirs=( ${#array_list[@]} )  # count of files and directories
+echo $ndirs
+
+for i in `seq 0 $imax $ndirs`; do
+    is=$i
+    ie=$(($is+$imax-1))
+    ie=$((ie<$ndirs ? ie: $ndirs-1));
+    echo "+-+-+-+-+-+-+-+-+-+-+-+-+-";
+    echo "$(($i+1)) loop";
+
+    for ii in `seq $is $ie`; do
+        echo "is: $is; ie: $ie; ii: $ii";
+        echo "****** $(($ii+1)). element:  ${array_list[$ii]} ******";
+        zip -qr kie-$i.zip $input_dir/${array_list[$ii]}
+    done
+    curl --silent --upload-file kie-$i.zip -u $CREDS -v https://repository.jboss.org/nexus/service/local/repositories/$repoID/content-compressed -H "Connection: keep-alive" -H "Keep-Alive: timeout=1800000, max=0"
+done


### PR DESCRIPTION
**Thank you for submitting this pull request**

Due to the `new` Nexus (or changes on the conf of server repositories.jboss.org) Nexus didn't admit any more files > 5G.
Instead of zipping one big file (about 11G) now it is zipped
drools
jbpm
dashbuilder
optaplanner
uberfire
and kie
All files a uploaded separately to Nexus. The kie.zip has 9g, so this has to be `split ted`.
The upload with these changes were tested and all worked properly.
Hopefully the release pipeline will not fail any more.


)You can check Kiegroup organization repositories CI status from [Chain Status webpage](https://kiegroup.github.io/droolsjbpm-build-bootstrap/)

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest</b> (using <i>this</i> e.g. <b>Jenkins retest this</b> optional but no longer required)
 
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
    
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
