### PR TITLE
new stage for checking type of staging-repository

### DIFF
--- a/.ci/jenkins/Jenkinsfile.release
+++ b/.ci/jenkins/Jenkinsfile.release
@@ -242,6 +242,27 @@ pipeline {
                 }
             }
         }
+        stage('status of staging-repository'){
+            when{
+                expression { runBuild == 'YES'}
+            }
+            steps {
+		        withCredentials([usernameColonPassword(credentialsId: 'kie_upload_Nexus', variable: 'CREDS')]) {
+    		        script{
+				        env.STAGING_STATUS = ""
+				        counter=0
+				        while( "${env.STAGING_STATUS}" != "closed" ){
+    				        env.STAGING_STATUS = sh(script: """ curl -u $CREDS -H 'Accept: application/json' -H 'Content-Type: application/json' https://repository.jboss.org/nexus/service/local/staging/profile_repositories/15c58a1abc895b | grep -oP '$repoID\",\"type\":\"\\K[^\"]+(?=\")' """, returnStdout: true).trim()
+    				        echo "staging-repository is still ${STAGING_STATUS}"
+    				        sleep(60*15)
+    				        counter=counter+1
+    				        echo "counter: $counter"
+				        }
+				        echo "staging-repository is ${STAGING_STATUS} now"
+		            }
+	            }
+            }
+        }
         stage('Additional tests for community') {
             when{
                 expression { runBuild == 'YES'}


### PR DESCRIPTION
**Thank you for submitting this pull request**

The release pipeline failed because once with a CURL was closed the staging-repository Nexus needs about 15 minutes to run all checks for closing the staging-rep. The uploaded artifacts are available after the closure on Nexus finishes.
The following step in release pipeline was to run the `additional tests` and these need the uploaded artifacts but the Nexus staging-repository is still closing, and so the artifacts are not yet available.
Now it checks the `type` [open or closed] and waits at least for 15 minutes, in case if everything works fine this time should be enough for closing, in case something happens with Nexus it will repeat every 15 minutes this check.

You can check Kiegroup organization repositories CI status from [Chain Status webpage](https://kiegroup.github.io/droolsjbpm-build-bootstrap/)

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest</b> (using <i>this</i> e.g. <b>Jenkins retest this</b> optional but no longer required)
 
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
    
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
