### PR TITLE
[7.67.x-blue] BAPL-2293 Remove OptaPlanner from the build

### DIFF
--- a/script/repository-list.txt
+++ b/script/repository-list.txt
@@ -2,7 +2,6 @@ droolsjbpm-build-bootstrap
 kie-soup
 droolsjbpm-knowledge
 drools
-optaplanner
 lienzo-core
 lienzo-tests
 appformer
@@ -18,7 +17,5 @@ jbpm-wb
 kie-wb-distributions
 openshift-drools-hacep
 process-migration-service
-optaweb-employee-rostering
-optaweb-vehicle-routing
 kie-jpmml-integration
 kie-docs


### PR DESCRIPTION
Follows up on #1975. Now there are no dependencies on `optaplanner` in the other repositories.

```
$ ./droolsjbpm-build-bootstrap/script/checks/repo-dep-tree.pl -w -t kie-wb-distributions
You need to build following repositories before building 'kie-wb-distributions' (in order):
droolsjbpm-build-bootstrap,kie-soup,lienzo-core,lienzo-tests,appformer,droolsjbpm-knowledge,drools,jbpm,droolsjbpm-integration,kie-wb-playground,kie-wb-common,drools-wb,jbpm-designer,jbpm-work-items,kie-uberfire-extensions,jbpm-wb,kie-wb-distributions
```

### JIRA
https://issues.redhat.com/browse/BAPL-2293

You can check Kiegroup organization repositories CI status from [Chain Status webpage](https://kiegroup.github.io/droolsjbpm-build-bootstrap/)

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest</b> (using <i>this</i> e.g. <b>Jenkins retest this</b> optional but no longer required)
 
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
    
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
