### PR TITLE
[7.67.x-blue] Bump xalan from 2.7.1 to 2.7.2 (#1993)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -281,7 +281,7 @@
     <version.rome>1.0</version.rome>
     <version.tomcat>9.0.22</version.tomcat>
     <version.wsdl4j>1.6.3</version.wsdl4j>
-    <version.xalan>2.7.1</version.xalan>
+    <version.xalan>2.7.2</version.xalan>
     <version.xerces>2.12.0.SP03</version.xerces>
     <version.xml-apis>1.4.01</version.xml-apis>
     <version.xml-apis-ext>1.3.04</version.xml-apis-ext>


### PR DESCRIPTION
Back port of https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1993

You can check Kiegroup organization repositories CI status from [Chain Status webpage](https://kiegroup.github.io/droolsjbpm-build-bootstrap/)

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest</b> (using <i>this</i> e.g. <b>Jenkins retest this</b> optional but no longer required)
 
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
    
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
