### PR TITLE
Drools 5456 - Some Drools Projects don't compile with JDK 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -492,9 +492,9 @@
     <version.shade.plugin>3.2.4</version.shade.plugin>
 
     <!-- maven-compiler-plugin -->
-    <maven.compiler.target>11</maven.compiler.target>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.release>11</maven.compiler.release>
+    <maven.compiler.target>8</maven.compiler.target>
+    <maven.compiler.source>8</maven.compiler.source>
+    <maven.compiler.release>8</maven.compiler.release>
   </properties>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -490,11 +490,6 @@
     <!-- ************** -->
 
     <version.shade.plugin>3.2.4</version.shade.plugin>
-
-    <!-- maven-compiler-plugin -->
-    <maven.compiler.target>8</maven.compiler.target>
-    <maven.compiler.source>8</maven.compiler.source>
-    <maven.compiler.release>8</maven.compiler.release>
   </properties>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -401,7 +401,7 @@
     <!-- Set to "true" on every project that has no violations. -->
     <spotbugs.failOnViolation>false</spotbugs.failOnViolation>
     <!-- org.eclipse.tycho plugin version -->
-    <version.org.eclipse.tycho>1.0.0</version.org.eclipse.tycho>
+    <version.org.eclipse.tycho>2.3.0</version.org.eclipse.tycho>
     <version.org.jboss.tools.tycho-plugins>1.0.0</version.org.jboss.tools.tycho-plugins>
     <!-- replaces findbugs-maven-plugin -->
     <version.com.github.spotbugs-maven-plugin>3.1.8</version.com.github.spotbugs-maven-plugin>
@@ -484,6 +484,17 @@
     <version.org.jvnet.jaxb2.maven2.maven-jaxb2-plugin>0.14.0</version.org.jvnet.jaxb2.maven2.maven-jaxb2-plugin>
     <version.org.mock-server>5.11.1</version.org.mock-server>
     <version.org.apache.kafka>2.8.1</version.org.apache.kafka>
+
+    <!-- ************** -->
+    <!-- Build settings -->
+    <!-- ************** -->
+
+    <version.shade.plugin>3.2.4</version.shade.plugin>
+
+    <!-- maven-compiler-plugin -->
+    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.release>11</maven.compiler.release>
   </properties>
 
   <repositories>
@@ -603,6 +614,21 @@
     </extensions>
     <pluginManagement>
       <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <version>${version.compiler.plugin}</version>
+            <configuration>
+              <showDeprecation>true</showDeprecation>
+              <showWarnings>true</showWarnings>
+              <release>${maven.compiler.release}</release>
+              <testSource>${maven.compiler.argument.testSource}</testSource>
+              <testTarget>${maven.compiler.argument.testTarget}</testTarget>
+              <compilerArgs>
+                <arg>-Xlint:unchecked</arg>
+              </compilerArgs>
+            </configuration>
+          </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>


### PR DESCRIPTION
https://issues.redhat.com/browse/DROOLS-5456

Updates to build under JDK 11.
This PR makes the following updates to allow the Drools Projects to build under JDK 11: * Updates version.org.eclipse.tycho to 2.3.0 to add support for JDK 11 * Updates the Maven Compile Goal to use the RELEASE nomenclature.

Jenkins run fdb
