### PR TITLE
[7.67.x-blue] RHPAM-4455 org.w3c.dom.* ignored from ban-duplicated-classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -789,10 +789,9 @@
                       <ignoreClass>org.apache.xmlbeans.xml.stream.ReferenceResolver</ignoreClass>
                       <ignoreClass>org.apache.xmlbeans.xml.stream.XMLEvent</ignoreClass>
                       <ignoreClass>org.apache.xmlbeans.xml.stream.Location</ignoreClass>
-                      <!-- Duplicated in xml-apis:xml-apis:jar:1.4.01 and xerces:xercesImpl:jar:2.11.0.SP4. The class is identical
+                      <!-- Duplicated in  xml-apis:xml-apis:jar:1.4.01 and xerces:xercesImpl:jar:2.12.2. The classes are identical
                            and there is very little chance this will get ever fixed. -->
-                      <ignoreClass>org.w3c.dom.ElementTraversal</ignoreClass>
-                      <ignoreClass>org.w3c.dom.UserDataHandler</ignoreClass>
+                      <ignoreClass>org.w3c.dom.*</ignoreClass>
                       <!-- Packaged both in hornetq-commons and hornetq-client. Remove this once we move the testing
                            from HornetQ to ActiveMQ (https://issues.jboss.org/browse/JBPM-5503) -->
                       <ignoreClass>org.hornetq.utils.HornetQUtilBundle_$bundle</ignoreClass>


### PR DESCRIPTION
Ticket: https://issues.redhat.com/browse/RHPAM-4455

- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/2028
- https://github.com/kiegroup/droolsjbpm-integration/pull/2837
- https://github.com/kiegroup/kie-wb-common/pull/3761
- https://github.com/kiegroup/kie-wb-distributions/pull/1179

Backporting:

- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/2023