### PR TITLE
added java -version to show up in the logs

### DIFF
--- a/.ci/compilation-config.yaml
+++ b/.ci/compilation-config.yaml
@@ -5,6 +5,7 @@ dependencies: ./project-dependencies.yaml
 pre: |
   export BUILD_MVN_OPTS="${{ env.BUILD_MVN_OPTS }} dependency:tree -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3
   echo "BUILD_MVN_OPTS=${{ env.BUILD_MVN_OPTS }}"
+  java -version
 
 default:
   build-command:

--- a/.ci/daily-config.yaml
+++ b/.ci/daily-config.yaml
@@ -6,6 +6,7 @@ pre: |
   export MAVEN_COMMAND=mvn -B -e -U clean deploy -Dfull -Drelease -DaltDeploymentRepository=local::default::file://${{ env.WORKSPACE }}/deploy-dir -Dmaven.test.redirectTestOutputToFile=true -Dmaven.test.failure.ignore=true -Dgwt.memory.settings="-Xmx10g" -Prun-code-coverage -Dcontainer.profile=wildfly -Dcontainer=wildfly -Dintegration-tests=true -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3
   echo "MAVEN_COMMAND=" ${{ env.MAVEN_COMMAND }}
   echo "WORKSPACE=" ${{ env.WORKSPACE }}
+  java -version
 
 default:
   build-command:

--- a/.ci/full-downstream-config.yaml
+++ b/.ci/full-downstream-config.yaml
@@ -5,6 +5,7 @@ dependencies: ./project-dependencies.yaml
 pre: |
   export BUILD_MVN_OPTS="${{ env.BUILD_MVN_OPTS }} dependency:tree -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3
   echo "BUILD_MVN_OPTS=${{ env.BUILD_MVN_OPTS }}"
+  java -version
 
 default:
   build-command:

--- a/.ci/pull-request-config.yaml
+++ b/.ci/pull-request-config.yaml
@@ -5,6 +5,7 @@ dependencies: ./project-dependencies.yaml
 pre: |
   export BUILD_MVN_OPTS="${{ env.BUILD_MVN_OPTS }} dependency:tree -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3
   echo "BUILD_MVN_OPTS=${{ env.BUILD_MVN_OPTS }}"
+  java -version
 
 default:
   build-command:

--- a/.ci/release-config.yaml
+++ b/.ci/release-config.yaml
@@ -5,6 +5,7 @@ dependencies: ./project-dependencies.yaml
 pre: |
   export MAVEN_COMMAND=mvn -B -e -U clean deploy -Dfull -Drelease -DaltDeploymentRepository=local::default::file://${{ env.WORKSPACE }}/community-deploy-dir -Dmaven.test.redirectTestOutputToFile=true -Dmaven.test.failure.ignore=true -Dgwt.memory.settings="-Xmx10g" -Prun-code-coverage -Dcontainer.profile=wildfly -Dcontainer=wildfly -Dintegration-tests=true -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3
   echo "MAVEN_COMMAND=" ${{ env.MAVEN_COMMAND }}
+  java -version
 default:
   build-command:
     current: |


### PR DESCRIPTION

added `java -version` to PRs, FDBs, CDBs, daily builds and releases

**Thank you for submitting this pull request**

**JIRA**: _(please edit the JIRA link if it exists)_ 

[link](https://www.example.com)

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* paste the link(s) from GitHub here
* link 2
* link 3 etc.

You can check Kiegroup organization repositories CI status from [Chain Status webpage](https://kiegroup.github.io/droolsjbpm-build-bootstrap/)

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest</b> (using <i>this</i> e.g. <b>Jenkins retest this</b> optional but no longer required)
 
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
    
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
