### PR TITLE
DROOLS-7105 DMN upgrade to Antlr 4.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -939,14 +939,14 @@
                       <!-- antlr4gwt and antlr4-c3-gwt (javax.json) rely on duplicated resources to provide a GWT-compatible
                            implementation for ANTLR -->
                       <dependency>
-                        <groupId>org.antlr</groupId>
+                        <groupId>org.antlr4gwt</groupId>
                         <artifactId>antlr4gwt-runtime</artifactId>
                         <ignoreClasses>
                           <ignoreClass>org.antlr.v4.*</ignoreClass>
                         </ignoreClasses>
                       </dependency>
                       <dependency>
-                        <groupId>org.antlr</groupId>
+                        <groupId>org.antlr4gwt</groupId>
                         <artifactId>antlr4gwt-annotations</artifactId>
                         <ignoreClasses>
                           <ignoreClass>org.antlr.v4.runtime.misc.*</ignoreClass>

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
     <version.okhttp>3.12.1</version.okhttp>
     <version.antlr>2.7.7</version.antlr>
     <version.org.antlr>3.5.2</version.org.antlr>
-    <version.org.antlrgwt>4.8.2</version.org.antlrgwt>
+    <version.org.antlrgwt>4.10.0</version.org.antlrgwt>
     <version.org.antlr4c3gwt>1.1.12</version.org.antlr4c3gwt>
     <version.org.antlr.ST4>4.0.7</version.org.antlr.ST4>
     <version.org.apache.abdera>1.1.3</version.org.apache.abdera>
@@ -3015,13 +3015,13 @@
       </dependency>
 
       <dependency>
-        <groupId>org.antlr</groupId>
+        <groupId>org.antlr4gwt</groupId>
         <artifactId>antlr4gwt-runtime</artifactId>
         <version>${version.org.antlrgwt}</version>
       </dependency>
 
       <dependency>
-        <groupId>org.antlr</groupId>
+        <groupId>org.antlr4gwt</groupId>
         <artifactId>antlr4gwt-runtime</artifactId>
         <version>${version.org.antlrgwt}</version>
         <classifier>sources</classifier>

--- a/pom.xml
+++ b/pom.xml
@@ -310,7 +310,7 @@
     <version.com.github.tomakehurst.wiremock>1.53</version.com.github.tomakehurst.wiremock>
     <version.com.google.android>4.1.1.4</version.com.google.android>
     <version.com.google.testing.compile>0.11</version.com.google.testing.compile>
-    <version.org.antlr4>4.10</version.org.antlr4>
+    <version.org.antlr4>4.10.1</version.org.antlr4>
     <!-- CXF's version is aligned with Jetty -->
     <version.org.apache.cxf>3.4.5</version.org.apache.cxf>
     <version.org.apache.camel>2.24.0</version.org.apache.camel>

--- a/pom.xml
+++ b/pom.xml
@@ -310,7 +310,7 @@
     <version.com.github.tomakehurst.wiremock>1.53</version.com.github.tomakehurst.wiremock>
     <version.com.google.android>4.1.1.4</version.com.google.android>
     <version.com.google.testing.compile>0.11</version.com.google.testing.compile>
-    <version.org.antlr4>4.9.2</version.org.antlr4>
+    <version.org.antlr4>4.10</version.org.antlr4>
     <!-- CXF's version is aligned with Jetty -->
     <version.org.apache.cxf>3.4.5</version.org.apache.cxf>
     <version.org.apache.camel>2.24.0</version.org.apache.camel>


### PR DESCRIPTION
7.x backport to keep aligned Antlr version for Drools DMN engine
 
ref https://github.com/quarkusio/quarkus/pull/27298#issuecomment-1216705851

**JIRA**: https://issues.redhat.com/browse/DROOLS-7105

**referenced Pull Requests**:
- (main) https://github.com/kiegroup/drools/pull/4614
- (7.x for alignment) https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/2031
- (7.x for alignment) https://github.com/kiegroup/drools/pull/4632
- (7.x for alignment) https://github.com/kiegroup/kie-wb-common/pull/3769
- (7.x for alignment) https://github.com/kiegroup/drools-wb/pull/1552
- (7.x for alignment) https://github.com/kiegroup/kie-wb-distributions/pull/1187

You can check Kiegroup organization repositories CI status from [Chain Status webpage](https://kiegroup.github.io/droolsjbpm-build-bootstrap/)

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest</b> (using <i>this</i> e.g. <b>Jenkins retest this</b> optional but no longer required)
 
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
    
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
