### PR TITLE
[BXMSPROD-1772] Improved build documentation

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,7 +19,19 @@ How to replicate CI configuration locally?
 
 Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
  
-[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
+[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used locally on command line or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it. 
+
+A general local execution could be the following one, where the tool clones all dependent projects starting from the `-sp` one and it locally applies the pull request (if it exists) in order to reproduce a complete build scenario for the provided *Pull Request*.
+
+> **Note:** the tool considers multiple *Pull Requests* related to each other if their branches (generally in the forked repositories) have the same name.
+
+``` shell
+$ build-chain-action -df 'https://raw.githubusercontent.com/${GROUP:kiegroup}/droolsjbpm-build-bootstrap/${BRANCH:main}/.ci/pull-request-config.yaml' build pr -url <pull-request-url> -sp kiegroup/kie-wb-distributions [--skipExecution]
+```
+
+> Consider changing `kiegroup/kie-wb-distributions` with the correct starting project.
+
+
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -440,15 +440,17 @@ If the purpose, instead, is to build the RHBA set of projects that are dependent
     $ npm i @kie/build-chain-action
     ```
 
-Now in according to what you need you only have to run the *build-chain-action* tool with proper arguments. Here we will provide the most common use cases you might face into. Check [build-chain](https://github.com/kiegroup/github-action-build-chain#github-action-build-chain) documentation if you need further details on commands and arguments.
+Now in according to then need, the *build-chain-action* command line tool should be run with proper arguments. Check [build-chain](https://github.com/kiegroup/github-action-build-chain#github-action-build-chain) documentation for further details on commands and arguments. Below one of the most common use cases you might face into. 
 
-* **Branch Flow**, this allows you to build the *whole set of projects* from RHBA community stream, either following upstream or downstream flow:
+* **Branch Flow**, this allows to build the *whole set of projects* from RHBA community stream, either following upstream or downstream flow:
 
     ``` shell
-    $ build-chain-action -df <definition-file> build branch -b <br> --fullProjectDependencyTree -sp <starting-project> [--skipExecution]
+    $ build-chain-action -df https://raw.githubusercontent.com/kiegroup/droolsjbpm-build-bootstrap/main/.ci/compilation-config.yaml build branch -b main --fullProjectDependencyTree -sp kiegroup/droolsjbpm-build-bootstrap [--skipExecution]
     ```
 
-    Using this command you can clone all repositories starting from specific project (see [project structure](#kiegroup-project-structure)), checkout one by one all projects and build them in according to their specific build instructions that are defined in the definition file you provided.
+    > Consider to change `main` by the branch/tag to build
+
+    This command clones all repositories starting from specific project (in this case *kiegroup/droolsjbpm-build-bootstrap*, see [project structure](#kiegroup-project-structure)), checkouts one by one all projects and build them in according to their specific build instructions that are defined in the definition file you provided.
     
     - `-df <definition-file>`, url or path to the build-chain definition file (more details [here](https://github.com/kiegroup/build-chain-configuration-reader)).
     - `build`, build functionality.
@@ -457,31 +459,7 @@ Now in according to what you need you only have to run the *build-chain-action* 
     - `-sp <starting-project>`, from which project (in the tree structure) start from.
     - `--skipExecution`, add this if you only want to clone all repositories without building them.
     
-    A real example could be this one, where you checkout and build the whole set of projects starting from the root one (i.e., `kiegroup/droolsjbpm-build-bootstrap`):
-
-    ```shell
-    $ build-chain-action -df https://github.com/kiegroup/droolsjbpm-build-bootstrap/blob/main/.ci/compilation-config.yaml build branch -b main --fullProjectDependencyTree -sp kiegroup/droolsjbpm-build-bootstrap
-    ```
-
-* **Pull Request Flow**, build projects related to a specific Pull Request you are performing:
-
-    ``` shell
-    $ build-chain-action -df <definition-file> build pr -url <pull-request-url> [-sp <starting-project>] [--skipExecution]
-    ```
-
-    Consider the scenario where you have multiple PRs, related to the same topic, on different RHBA projects. With this command you are able to checkout all of them in the correct PR branch and build all of them. This will allow you to build and test the overall scenario having multiple PR-related projects.
-    
-    - `-df <definition-file>`, url or path to the build-chain definition file (more details [here](https://github.com/kiegroup/build-chain-configuration-reader)).
-    - `build`, build functionality.
-    - `pr -url <pull-request-url>`, for every projects checks if a Pull Request exists (having the same name of the provided one) and if yes it check outs in that branch.
-    - `-sp <starting-project>`, from which project (in the tree structure) start from, if not provided it starts from the PR one.
-    - `--skipExecution`, add this if you only want to clone all repositories without building them.
-
-    A real example could be this one, taken from `kie-wb-distribution` project:
-
-    ```shell
-    $ build-chain-action -df 'https://raw.githubusercontent.com/${GROUP:kiegroup}/droolsjbpm-build-bootstrap/${BRANCH:main}/.ci/pull-request-config.yaml' build pr -url https://github.com/kiegroup/kie-wb-distributions/pull/1166 
-    ```
+    More info on *branch flow* arguments usage in [Execution Build Action - Branch flow arguments](https://github.com/kiegroup/github-action-build-chain#execution-build-action---branch-flow-arguments)
 
 Running tests
 -------------

--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ Installing Maven
 Running the build
 -----------------
 
-Running the RHBA community projects build could differ in according to your purpose, which can be summarized in either *single project build* or *set of RHBA projects build*.
+Running the RHBA community stream build could differ in according to the purpose, which can be summarized in either *single project build* or *RHBA stream build*.
 
 ### **Single project:**
 
@@ -430,11 +430,11 @@ Those SNAPSHOTS were built and deployed last night by Jenkins jobs.
 
         Note that using `-nsu` will also make the build faster.
 
-### **Set of projects:**
+### **RHBA Stream**
 
-If you want, instead, to build a set of projects that are dependent on each other, we suggest using the [build-chain action](https://github.com/kiegroup/github-action-build-chain) tool. This tool allows you to build multiple projects from different repositories in one single command.
+If the purpose, instead, is to build the RHBA set of projects that are dependent on each other, the recommendation is to use the [build-chain](https://github.com/kiegroup/github-action-build-chain) tool. This tool allows to build multiple projects from different repositories in one single command.
 
-* Install **build-chain-action** npm tool (you must have node/npm installed):
+* Install **build-chain-action** npm tool (node/npm must be installed):
     
     ```shell
     $ npm i @kie/build-chain-action
@@ -460,7 +460,7 @@ Now in according to what you need you only have to run the *build-chain-action* 
     A real example could be this one, where you checkout and build the whole set of projects starting from the root one (i.e., `kiegroup/droolsjbpm-build-bootstrap`):
 
     ```shell
-    $ build-chain-action -df 'https://raw.githubusercontent.com/kiegroup/droolsjbpm-build-bootstrap/main/.ci/pull-request-config.yaml' build branch -b main --fullProjectDependencyTree -sp kiegroup/droolsjbpm-build-bootstrap
+    $ build-chain-action -df https://github.com/kiegroup/droolsjbpm-build-bootstrap/blob/main/.ci/compilation-config.yaml build branch -b main --fullProjectDependencyTree -sp kiegroup/droolsjbpm-build-bootstrap
     ```
 
 * **Pull Request Flow**, build projects related to a specific Pull Request you are performing:
@@ -494,9 +494,9 @@ Running tests
     ```
 
 
-* Set of projects
+* RHBA stream
     
-    This can be reached using the `build-chain-action` tool, introduced in [Running the Build](#running-the-build) section. Omitting the `--skipExecution` flag you will check out all projects and build them (also executing all tests).
+    This can be reached using the `build-chain` tool, introduced in [Running the Build](#running-the-build) section. Omitting the `--skipExecution` flag it will check out and build the whole set of RHBA projects (also executing all tests).
 
     ```shell
     $ build-chain-action -df <definition-file> build branch -b <br> --fullProjectDependencyTree -sp <starting-project>

--- a/README.md
+++ b/README.md
@@ -430,9 +430,9 @@ Those SNAPSHOTS were built and deployed last night by Jenkins jobs.
 
         Note that using `-nsu` will also make the build faster.
 
-### **RHBA Stream**
+### **Full build from sources**
 
-If the purpose, instead, is to build the RHBA set of projects that are dependent on each other, the recommendation is to use the [build-chain](https://github.com/kiegroup/github-action-build-chain) tool. This tool allows to build multiple projects from different repositories in one single command.
+If the purpose, instead, is to build the full set of projects that are dependent on each other, the recommendation is to use the [build-chain](https://github.com/kiegroup/github-action-build-chain) tool. This tool allows to build multiple projects from different repositories in one single command.
 
 * Install **build-chain-action** npm tool (node/npm must be installed):
     
@@ -472,7 +472,7 @@ Running tests
     ```
 
 
-* RHBA stream
+* Full build with tests
     
     This can be reached using the `build-chain` tool, introduced in [Running the Build](#running-the-build) section. Omitting the `--skipExecution` flag it will check out and build the whole set of RHBA projects (also executing all tests).
 


### PR DESCRIPTION
**Thank you for submitting this pull request**

**JIRA**:

- [BXMSPROD-1772](https://issues.redhat.com/browse/BXMSPROD-1772)

**referenced Pull Requests**: 

- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/2036

Improved the 'Running the Build' section by adding some examples using the `build-chain-action` tool.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest</b> (using <i>this</i> e.g. <b>Jenkins retest this</b> optional but no longer required)
 
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
    
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
