### PR TITLE
[BXMSPROD-1770] Centralize GHA Operating Systems Configuration

### DIFF
--- a/.ci/actions/os-preparation/action.yml
+++ b/.ci/actions/os-preparation/action.yml
@@ -10,8 +10,10 @@ runs:
         repository: kiegroup/droolsjbpm-build-bootstrap
         path: matrix_preparation
     - id: set-os
+      env:
+        repo_name: ${{ github.event.repository.name }}
+        event: ${{ github.event_name }}
+        label_name: ${{ github.event.label.name }}
       run: |
-        event=$(echo '${{ github.event_name }}')  
-        label_name=$(echo '${{ github.event.label.name }}')
-        operation_systems=$(jq --arg event "$event" --arg event_value "$label_name" 'map(. | select((.event==$event) and (.value==null or .value==$event_value)) )'  matrix.json | jq '.[] | .os' | jq -s 'flatten(1)')                
+        operating_systems=$(jq --arg repo "$repo_name" --arg event "$event" --arg event_value "$label_name" 'map(.| select(.event==$event and ((.value==null and ((.repository | index( $repo))) or (.repository==null)) or .value==$event_value)))' matrix.json | jq "if (length > 1) then (.[] | select(.repository!=null)) else (.[] | select(.repository==null)) end | .os")
         echo ::set-output name=operation_systems::$(echo $operation_systems)

--- a/.ci/actions/os-preparation/action.yml
+++ b/.ci/actions/os-preparation/action.yml
@@ -18,4 +18,4 @@ runs:
       shell: bash
       run: |
         operating_systems=$(jq --arg repo "$repo_name" --arg event "$event" --arg event_value "$label_name" 'map(.| select(.event==$event and ((.value==null and ((.repository | index( $repo))) or (.repository==null)) or .value==$event_value)))' matrix.json | jq "if (length > 1) then (.[] | select(.repository!=null)) else (.[] | select(.repository==null)) end | .os")
-        echo ::set-output name=operation_systems::$(echo $operation_systems)
+        echo ::set-output name=operation_systems::$(echo $operating_systems)

--- a/.ci/actions/os-preparation/action.yml
+++ b/.ci/actions/os-preparation/action.yml
@@ -14,6 +14,7 @@ runs:
         repo_name: ${{ github.event.repository.name }}
         event: ${{ github.event_name }}
         label_name: ${{ github.event.label.name }}
+      shell: bash
       run: |
         filtered_os=$(jq --arg repo "$repo_name" --arg event "$event" --arg event_value "$label_name" 'map(.| select(.event==$event and ((.value==null and ((.repository | index( $repo))) or (.repository==null)) or .value==$event_value)))' .ci/actions/os-preparation/matrix.json | jq "if (length > 1) then (.[] | select(.repository!=null)) else (.[] | select(.repository==null)) end | .os")
         echo ::set-output name=operating_systems::$filtered_os

--- a/.ci/actions/os-preparation/action.yml
+++ b/.ci/actions/os-preparation/action.yml
@@ -10,6 +10,7 @@ runs:
         repository: kiegroup/droolsjbpm-build-bootstrap
         path: matrix_preparation
     - id: set-os
+      working-directory: .ci/actions/os-preparation
       env:
         repo_name: ${{ github.event.repository.name }}
         event: ${{ github.event_name }}

--- a/.ci/actions/os-preparation/action.yml
+++ b/.ci/actions/os-preparation/action.yml
@@ -14,6 +14,7 @@ runs:
         repo_name: ${{ github.event.repository.name }}
         event: ${{ github.event_name }}
         label_name: ${{ github.event.label.name }}
+      shell: bash
       run: |
         operating_systems=$(jq --arg repo "$repo_name" --arg event "$event" --arg event_value "$label_name" 'map(.| select(.event==$event and ((.value==null and ((.repository | index( $repo))) or (.repository==null)) or .value==$event_value)))' matrix.json | jq "if (length > 1) then (.[] | select(.repository!=null)) else (.[] | select(.repository==null)) end | .os")
         echo ::set-output name=operation_systems::$(echo $operation_systems)

--- a/.ci/actions/os-preparation/action.yml
+++ b/.ci/actions/os-preparation/action.yml
@@ -1,0 +1,17 @@
+name: 'OS Preparation'
+description: 'Prepares the Operating Systems array'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Check out droolsjbpm-build-bootstrap
+      uses: actions/checkout@v3
+      with:
+        repository: kiegroup/droolsjbpm-build-bootstrap
+        path: matrix_preparation
+    - id: set-os
+      run: |
+        event=$(echo '${{ github.event_name }}')  
+        label_name=$(echo '${{ github.event.label.name }}')
+        operation_systems=$(jq --arg event "$event" --arg event_value "$label_name" 'map(. | select((.event==$event) and (.value==null or .value==$event_value)) )'  matrix.json | jq '.[] | .os' | jq -s 'flatten(1)')                
+        echo ::set-output name=operation_systems::$(echo $operation_systems)

--- a/.ci/actions/os-preparation/action.yml
+++ b/.ci/actions/os-preparation/action.yml
@@ -18,4 +18,4 @@ runs:
       shell: bash
       run: |
         operating_systems=$(jq --arg repo "$repo_name" --arg event "$event" --arg event_value "$label_name" 'map(.| select(.event==$event and ((.value==null and ((.repository | index( $repo))) or (.repository==null)) or .value==$event_value)))' matrix.json | jq "if (length > 1) then (.[] | select(.repository!=null)) else (.[] | select(.repository==null)) end | .os")
-        echo ::set-output name=operation_systems::$(echo $operating_systems)
+        echo ::set-output name=operating_systems::$(echo $operating_systems)

--- a/.ci/actions/os-preparation/action.yml
+++ b/.ci/actions/os-preparation/action.yml
@@ -10,12 +10,10 @@ runs:
         repository: kiegroup/droolsjbpm-build-bootstrap
         path: matrix_preparation
     - id: set-os
-      working-directory: .ci/actions/os-preparation
       env:
         repo_name: ${{ github.event.repository.name }}
         event: ${{ github.event_name }}
         label_name: ${{ github.event.label.name }}
-      shell: bash
       run: |
-        operating_systems=$(jq --arg repo "$repo_name" --arg event "$event" --arg event_value "$label_name" 'map(.| select(.event==$event and ((.value==null and ((.repository | index( $repo))) or (.repository==null)) or .value==$event_value)))' matrix.json | jq "if (length > 1) then (.[] | select(.repository!=null)) else (.[] | select(.repository==null)) end | .os")
-        echo ::set-output name=operating_systems::$(echo $operating_systems)
+        filtered_os=$(jq --arg repo "$repo_name" --arg event "$event" --arg event_value "$label_name" 'map(.| select(.event==$event and ((.value==null and ((.repository | index( $repo))) or (.repository==null)) or .value==$event_value)))' .ci/actions/os-preparation/matrix.json | jq "if (length > 1) then (.[] | select(.repository!=null)) else (.[] | select(.repository==null)) end | .os")
+        echo ::set-output name=operating_systems::$filtered_os

--- a/.ci/actions/os-preparation/matrix.json
+++ b/.ci/actions/os-preparation/matrix.json
@@ -1,0 +1,11 @@
+[
+  {
+      "os": ["ubuntu-latest"],
+      "event":"pull_request"
+  },
+  {
+      "os": ["windows-2022"],
+      "event":"label",
+      "value":"windows_check"
+  }
+]

--- a/.ci/actions/os-preparation/matrix.json
+++ b/.ci/actions/os-preparation/matrix.json
@@ -5,7 +5,7 @@
   }, 
   {
     "os": ["ubuntu", "windows"],
-    "repository": ["kiegroup/drools"],
+    "repository": ["drools"],
     "event":"pull_request"
   },
   {

--- a/.ci/actions/os-preparation/matrix.json
+++ b/.ci/actions/os-preparation/matrix.json
@@ -1,11 +1,16 @@
 [
   {
-      "os": ["ubuntu-latest"],
-      "event":"pull_request"
+    "os": ["ubuntu-latest"],
+    "event":"pull_request"
+  }, 
+  {
+    "os": ["ubuntu", "windows"],
+    "repository": ["kiegroup/drools"],
+    "event":"pull_request"
   },
   {
-      "os": ["windows-2022"],
-      "event":"label",
-      "value":"windows_check"
+    "os": ["windows-2022"],
+    "event":"label",
+    "value":"windows_check"
   }
 ]

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -50,4 +50,6 @@ How to retest this PR or trigger a specific build:
 * <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>
 
 * <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
+
+* <b>to use a windows runner</b> for <b>github actions</b> please add the label `windows_check`
 </details>

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -18,8 +18,10 @@ jobs:
     outputs:
       os: ${{ steps.set-os.outputs.operation_systems }}
     steps:
+    - name: Check out local droolsjbpm-build-bootstrap
+      uses: actions/checkout@v3
     - name: OS Preparation
-      uses: kiegroup/droolsjbpm-build-bootstrap/.ci/actions/os-preparation@main
+      uses: ./.ci/actions/os-preparation
   build-chain:
     needs: os-prep
     if: needs.os-prep.outputs.os

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -21,6 +21,7 @@ jobs:
     - name: Check out local droolsjbpm-build-bootstrap
       uses: actions/checkout@v3
     - name: OS Preparation
+      id: set-os
       uses: ./.ci/actions/os-preparation
     - name: Check os matrix output
       run: echo "Configured operating systems ${{ steps.set-os.outputs.operating_systems }}"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -22,6 +22,8 @@ jobs:
       uses: actions/checkout@v3
     - name: OS Preparation
       uses: ./.ci/actions/os-preparation
+    - name: Check os matrix output
+      run: echo "Configured operating systems ${{ steps.set-os.outputs.operating_systems }}"
   build-chain:
     needs: os-prep
     concurrency:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -2,7 +2,7 @@ name: Build Chain
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, labeled]
     paths-ignore:
       - 'LICENSE*'
       - '.gitignore'
@@ -13,13 +13,21 @@ on:
       - 'script/**'
 
 jobs:
+  os-prep:
+    runs-on: ubuntu-latest
+    outputs:
+      os: ${{ steps.set-os.outputs.operation_systems }}
+    steps:
+    - name: OS Preparation
+      uses: kiegroup/droolsjbpm-build-bootstrap/.ci/actions/os-preparation@main
   build-chain:
+    needs: os-prep
     concurrency:
       group: pull_request-${{ github.head_ref }}
       cancel-in-progress: true
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: ${{ needs.os-prep.outputs.os }}
         java-version: [8, 11]
         maven-version: ['3.8.1']
       fail-fast: true

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -22,6 +22,7 @@ jobs:
       uses: kiegroup/droolsjbpm-build-bootstrap/.ci/actions/os-preparation@main
   build-chain:
     needs: os-prep
+    if: needs.os-prep.outputs.os
     concurrency:
       group: pull_request-${{ github.head_ref }}
       cancel-in-progress: true

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -24,7 +24,7 @@ jobs:
       uses: ./.ci/actions/os-preparation
   build-chain:
     needs: os-prep
-    if: needs.os-prep.outputs.os
+    # if: needs.os-prep.outputs.os
     concurrency:
       group: pull_request-${{ github.head_ref }}
       cancel-in-progress: true

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -16,7 +16,7 @@ jobs:
   os-prep:
     runs-on: ubuntu-latest
     outputs:
-      os: ${{ steps.set-os.outputs.operation_systems }}
+      os: ${{ steps.set-os.outputs.operating_systems }}
     steps:
     - name: Check out local droolsjbpm-build-bootstrap
       uses: actions/checkout@v3

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -24,7 +24,6 @@ jobs:
       uses: ./.ci/actions/os-preparation
   build-chain:
     needs: os-prep
-    # if: needs.os-prep.outputs.os
     concurrency:
       group: pull_request-${{ github.head_ref }}
       cancel-in-progress: true


### PR DESCRIPTION
**Thank you for submitting this pull request**

**JIRA**:
- https://issues.redhat.com/browse/BXMSPROD-1770

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

Improvements:
- Added `os-preparation` action that produces the operating systems list
- Updated Pull Request workflow to prepare the os config just before `build-chain` job take place

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used locally on command line or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it. 

A general local execution could be the following one, where the tool clones all dependent projects starting from the `-sp` one and it locally applies the pull request (if it exists) in order to reproduce a complete build scenario for the provided *Pull Request*.

> **Note:** the tool considers multiple *Pull Requests* related to each other if their branches (generally in the forked repositories) have the same name.

``` shell
$ build-chain-action -df 'https://raw.githubusercontent.com/${GROUP:kiegroup}/droolsjbpm-build-bootstrap/${BRANCH:main}/.ci/pull-request-config.yaml' build pr -url <pull-request-url> -sp kiegroup/kie-wb-distributions [--skipExecution]
```

> Consider changing `kiegroup/kie-wb-distributions` with the correct starting project.


</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest</b> (using <i>this</i> e.g. <b>Jenkins retest this</b> optional but no longer required)
 
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
    
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
