### PR TITLE
[7.67.x-blue] opta projects removed from project-dependencies

### DIFF
--- a/.ci/project-dependencies.yaml
+++ b/.ci/project-dependencies.yaml
@@ -33,9 +33,6 @@ dependencies:
           - source: main
             target: 7.x
       exclude:
-        - kiegroup/optaweb-employee-rostering
-        - kiegroup/optaweb-vehicle-routing
-        - kiegroup/optaplanner
         - kiegroup/drools
 
   - project: kiegroup/drools
@@ -52,41 +49,12 @@ dependencies:
           - source: main
             target: 7.x
       exclude:
-        - kiegroup/optaweb-employee-rostering
-        - kiegroup/optaweb-vehicle-routing
-        - kiegroup/optaplanner          
         - kiegroup/droolsjbpm-knowledge          
 
   - project: kiegroup/jbpm
     dependencies:
       - project: kiegroup/drools
       - project: kiegroup/kie-soup
-
-  - project: kiegroup/optaplanner
-    dependencies:
-      - project: kiegroup/drools
-    mapping:
-      dependencies:
-        default:
-          - source: 7.x
-            target: main
-        kiegroup/drools:
-          - source: main
-            target: 7.x
-          - source: 7.x
-            target: 7.x
-        kiegroup/droolsjbpm-knowledge:
-          - source: main
-            target: 7.x
-          - source: 7.x
-            target: 7.x
-      dependant:
-        default:
-          - source: main
-            target: 7.x
-      exclude:
-        - kiegroup/optaweb-employee-rostering  
-        - kiegroup/optaweb-vehicle-routing
 
   - project: kiegroup/kie-jpmml-integration
     dependencies:
@@ -95,7 +63,6 @@ dependencies:
 
   - project: kiegroup/droolsjbpm-integration
     dependencies:
-      - project: kiegroup/optaplanner
       - project: kiegroup/drools
       - project: kiegroup/jbpm
 
@@ -134,63 +101,10 @@ dependencies:
 
   - project: kiegroup/kie-docs
 
-  - project: kiegroup/optaweb-employee-rostering
-    dependencies:
-      - project: kiegroup/optaplanner
-    mapping:
-      dependencies:
-        default:
-          - source: 7.x
-            target: main
-        kiegroup/drools:
-          - source: main
-            target: 7.x
-          - source: 7.x
-            target: 7.x
-        kiegroup/droolsjbpm-knowledge:
-          - source: main
-            target: 7.x
-          - source: 7.x
-            target: 7.x
-      dependant:
-        default:
-          - source: main
-            target: 7.x
-      exclude:
-        - kiegroup/optaweb-vehicle-routing  
-        - kiegroup/optaplanner
-
-  - project: kiegroup/optaweb-vehicle-routing
-    dependencies:
-      - project: kiegroup/optaplanner
-    mapping:
-      dependencies:
-        default:
-          - source: 7.x
-            target: main
-        kiegroup/drools:
-          - source: main
-            target: 7.x
-          - source: 7.x
-            target: 7.x
-        kiegroup/droolsjbpm-knowledge:
-          - source: main
-            target: 7.x
-          - source: 7.x
-            target: 7.x
-      dependant:
-        default:
-          - source: main
-            target: 7.x
-      exclude:
-        - kiegroup/optaweb-employee-rostering  
-        - kiegroup/optaplanner
-
   - project: kiegroup/kie-wb-distributions
     dependencies:
       - project: kiegroup/kie-soup
       - project: kiegroup/drools
-      - project: kiegroup/optaplanner
       - project: kiegroup/jbpm-wb
       - project: kiegroup/appformer
       - project: kiegroup/kie-uberfire-extensions


### PR DESCRIPTION
You can check Kiegroup organization repositories CI status from [Chain Status webpage](https://kiegroup.github.io/droolsjbpm-build-bootstrap/)
repository-list and diagram image will automatically replaced by github action

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used locally on command line or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it. 

A general local execution could be the following one, where the tool clones all dependent projects starting from the `-sp` one and it locally applies the pull request (if it exists) in order to reproduce a complete build scenario for the provided *Pull Request*.

> **Note:** the tool considers multiple *Pull Requests* related to each other if their branches (generally in the forked repositories) have the same name.

``` shell
$ build-chain-action -df 'https://raw.githubusercontent.com/${GROUP:kiegroup}/droolsjbpm-build-bootstrap/${BRANCH:main}/.ci/pull-request-config.yaml' build pr -url <pull-request-url> -sp kiegroup/kie-wb-distributions [--skipExecution]
```

> Consider changing `kiegroup/kie-wb-distributions` with the correct starting project.


</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest</b> (using <i>this</i> e.g. <b>Jenkins retest this</b> optional but no longer required)
 
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
    
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
