### PR TITLE
[7.67.x-blue][BXMSPROD-1889] add stage to create tag in prod repositories in Jenkinsfile.nightly

### DIFF
--- a/.ci/jenkins/Jenkinsfile.nightly
+++ b/.ci/jenkins/Jenkinsfile.nightly
@@ -1,6 +1,7 @@
 @Library('jenkins-pipeline-shared-libraries')_
 
 localNexusRepositoryId = "${env.LOCAL_NEXUS_REPOSITORY_ID?.trim() ? LOCAL_NEXUS_REPOSITORY_ID : 'rhba-8.0-nightly'}"
+def tagName = "nightly-${PRODUCT_VERSION}.redhat-${new Date().format('yyyyMMddHHmm')}"
 
 pipeline {
     agent {
@@ -82,6 +83,25 @@ pipeline {
                 }
             }
         }
+        stage ("Create tags in prod repositories") {
+            steps {
+                script {
+                    def projectsToTagWithProdRepoName = ["jboss-integration/bxms-patch-tools": "bxms-patch-tools"]
+                    projectsToTagWithProdRepoName.each { project ->
+                        def projectGroupName = util.getProjectGroupName(project.key)
+                        def group = projectGroupName[0]
+                        def name = projectGroupName[1]
+                        dir("${env.WORKSPACE}/${group}_${name}") {
+                            def remoteName = "prod"
+                            githubscm.commitChanges("PME changes for ${tagName}")
+                            githubscm.tagRepository(tagName)
+                            githubscm.addRemote(remoteName, "${env.PRODUCTIZATION_REPOSITORY_BASE_URL}/${project.value}")
+                            githubscm.pushRemoteTag(remoteName, tagName, "gerrit-user")
+                        }
+                    }
+                }
+            }
+        }
         stage('Generate RHPAM Properties Files') {
             steps {
                 script {
@@ -90,6 +110,7 @@ pipeline {
                     build job: env.RHPAM_PROPERTIES_GENERATOR_PATH, parameters: [
                         [$class: 'BooleanParameterValue', name: 'IS_RELEASE', value: false],
                         [$class: 'StringParameterValue', name: 'BRANCH_NAME', value: env.BRANCH_NAME],
+                        [$class: 'StringParameterValue', name: 'TAG_HASH', value: tagName],
                         [$class: 'StringParameterValue', name: 'KIE_VERSION', value: PME_BUILD_VARIABLES['kieVersion']],
                         [$class: 'StringParameterValue', name: 'PRODUCT_VERSION', value: PME_BUILD_VARIABLES['productVersion']],
                         [$class: 'StringParameterValue', name: 'TIME_STAMP', value: "${PME_BUILD_VARIABLES['datetimeSuffix']}"],


### PR DESCRIPTION
**JIRA**: https://issues.redhat.com/browse/BXMSPROD-1889

Related PRs:
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/2136
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/2148
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/2149


You can check Kiegroup organization repositories CI status from [Chain Status webpage](https://kiegroup.github.io/droolsjbpm-build-bootstrap/)

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used locally on command line or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it. 

A general local execution could be the following one, where the tool clones all dependent projects starting from the `-sp` one and it locally applies the pull request (if it exists) in order to reproduce a complete build scenario for the provided *Pull Request*.

> **Note:** the tool considers multiple *Pull Requests* related to each other if their branches (generally in the forked repositories) have the same name.

``` shell
$ build-chain-action -df 'https://raw.githubusercontent.com/${GROUP:kiegroup}/droolsjbpm-build-bootstrap/${BRANCH:main}/.ci/pull-request-config.yaml' build pr -url <pull-request-url> -sp kiegroup/kie-wb-distributions [--skipExecution]
```

> Consider changing `kiegroup/kie-wb-distributions` with the correct starting project.


</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest</b> (using <i>this</i> e.g. <b>Jenkins retest this</b> optional but no longer required)
 
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
    
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
