### PR TITLE
Disable version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
   schedule:
     interval: daily
     time: '03:00'
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 0
   target-branch: "main"
   commit-message:
     prefix: "[bot][main]"
@@ -14,7 +14,7 @@ updates:
   schedule:
     interval: daily
     time: '04:00'
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 0
   target-branch: "7.67.x"
   commit-message:
     prefix: "[bot][7.67.x]"
@@ -23,7 +23,7 @@ updates:
   schedule:
     interval: daily
     time: '05:00'
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 0
   target-branch: "7.67.x-blue"
   commit-message:
     prefix: "[bot][blue]"


### PR DESCRIPTION
Disable version updates while only keeping security updates

See:
- https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#overriding-the-default-behavior-with-a-configuration-file