### PR TITLE
[BXMSPROD-1892] Automated pull request backporting workflow

### DIFF
--- a/.ci/actions/backporting/action.yml
+++ b/.ci/actions/backporting/action.yml
@@ -9,17 +9,21 @@ inputs:
     description: "The cherry-pick pull request title"
     default: "${{ github.event.pull_request.title }}"
     required: false
-  original-pr-url:
-    description: "Original pull request url"
-    default: "${{ github.event.pull_request.html_url }}"
+  body:
+    description: "The cherry-pick pull request body"
+    default: "**Backport:** ${{ github.event.pull_request.html_url }}\r\n\r\n${{ github.event.pull_request.body }}"
     required: false
   original-pr-branch:
     description: "Original pull request branch name"
     default: "${{ github.event.pull_request.head.ref }}"
     required: false
-  reviewers:
-    description: "Reviewers to be added in the backported pull request"
+  author:
+    description: "Author of the original pull request"
     default: "${{ github.event.pull_request.user.login }}"
+    required: false
+  additional-reviewers:
+    description: "Additional backported pull request reviewers, e.g., toJSON(github.event.pull_request.requested_reviewers)"
+    default: "[]"
     required: false
 
 runs: 
@@ -29,16 +33,24 @@ runs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
+    - name: Prepare reviewers
+      id: prepare-reviewers
+      shell: bash
+      run: |
+        echo "Additional reviewers retrieved below"
+        echo "${{ inputs.additional-reviewers }}"
+        reviewers="$(echo ${{ inputs.additional-reviewers }} | jq -c 'map(.login)' | jq -cr '. |= . + ["${{ inputs.author }}"] | unique | join(",")')"
+        echo "reviewers = ${reviewers}"
+        echo "BACKPORT_REVIEWERS=${reviewers}" >> $GITHUB_ENV
     - name: Perform cherry pick
       id: cherry-pick
       uses: carloscastrojumo/github-cherry-pick-action@v1.0.5
       with:
         branch: "${{ inputs.target-branch }}"
         title: "[${{ inputs.target-branch }}] ${{ inputs.title }}"
-        body: "cherry-pick: ${{ inputs.original-pr-url }}"
+        body: "${{ inputs.body }}"
         labels: |
           cherry-pick :cherries:
         inherit_labels: false
         cherry-pick-branch: "${{ inputs.original-pr-branch }}_${{ inputs.target-branch }}"
-        reviewers: |
-          ${{ inputs.reviewers }}
+        reviewers: ${{ env.BACKPORT_REVIEWERS }}

--- a/.ci/actions/backporting/action.yml
+++ b/.ci/actions/backporting/action.yml
@@ -11,7 +11,11 @@ inputs:
     required: false
   body:
     description: "The cherry-pick pull request body"
-    default: "**Backport:** ${{ github.event.pull_request.html_url }}\r\n\r\n${{ github.event.pull_request.body }}"
+    default: "${{ github.event.pull_request.body }}"
+    required: false
+  original-pr-url:
+    description: "Original pull request url"
+    default: "${{ github.event.pull_request.html_url }}"
     required: false
   original-pr-branch:
     description: "Original pull request branch name"
@@ -48,7 +52,7 @@ runs:
       with:
         branch: "${{ inputs.target-branch }}"
         title: "[${{ inputs.target-branch }}] ${{ inputs.title }}"
-        body: "${{ inputs.body }}"
+        body: "**Backport:** ${{ original-pr-url }}\r\n\r\n${{ inputs.body }}"
         labels: |
           cherry-pick :cherries:
         inherit_labels: false

--- a/.ci/actions/backporting/action.yml
+++ b/.ci/actions/backporting/action.yml
@@ -52,7 +52,7 @@ runs:
       with:
         branch: "${{ inputs.target-branch }}"
         title: "[${{ inputs.target-branch }}] ${{ inputs.title }}"
-        body: "**Backport:** ${{ original-pr-url }}\r\n\r\n${{ inputs.body }}"
+        body: "**Backport:** ${{ inputs.original-pr-url }}\r\n\r\n${{ inputs.body }}"
         labels: |
           cherry-pick :cherries:
         inherit_labels: false

--- a/.ci/actions/backporting/action.yml
+++ b/.ci/actions/backporting/action.yml
@@ -31,9 +31,7 @@ runs:
         fetch-depth: 0
     - name: Perform cherry pick
       id: cherry-pick
-      # TODO: change to original one carloscastrojumo/github-cherry-pick-action@v1.0.3 
-      # when https://github.com/carloscastrojumo/github-cherry-pick-action/pull/26 merged
-      uses: lampajr/github-cherry-pick-action@issue-18_cp_branch_name
+      uses: carloscastrojumo/github-cherry-pick-action@v1.0.5
       with:
         branch: "${{ inputs.target-branch }}"
         title: "[${{ inputs.target-branch }}] ${{ inputs.title }}"

--- a/.ci/actions/backporting/action.yml
+++ b/.ci/actions/backporting/action.yml
@@ -1,0 +1,46 @@
+name: 'Pull Request Backporting'
+description: 'Creates a backporting pull request'
+
+inputs:
+  target-branch:
+    description: "The branch where the cherry-pick must be applied"
+    required: true
+  title:
+    description: "The cherry-pick pull request title"
+    default: "${{ github.event.pull_request.title }}"
+    required: false
+  original-pr-url:
+    description: "Original pull request url"
+    default: "${{ github.event.pull_request.html_url }}"
+    required: false
+  original-pr-branch:
+    description: "Original pull request branch name"
+    default: "${{ github.event.pull_request.head.ref }}"
+    required: false
+  reviewers:
+    description: "Reviewers to be added in the backported pull request"
+    default: "${{ github.event.pull_request.user.login }}"
+    required: false
+
+runs: 
+  using: 'composite'
+  steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Perform cherry pick
+      id: cherry-pick
+      # TODO: change to original one carloscastrojumo/github-cherry-pick-action@v1.0.3 
+      # when https://github.com/carloscastrojumo/github-cherry-pick-action/pull/26 merged
+      uses: lampajr/github-cherry-pick-action@issue-18_cp_branch_name
+      with:
+        branch: "${{ inputs.target-branch }}"
+        title: "[${{ inputs.target-branch }}] ${{ inputs.title }}"
+        body: "cherry-pick: ${{ inputs.original-pr-url }}"
+        labels: |
+          cherry-pick :cherries:
+        inherit_labels: false
+        cherry-pick-branch: "${{ inputs.original-pr-branch }}_${{ inputs.target-branch }}"
+        reviewers: |
+          ${{ inputs.reviewers }}

--- a/.ci/actions/backporting/action.yml
+++ b/.ci/actions/backporting/action.yml
@@ -52,5 +52,5 @@ runs:
         labels: |
           cherry-pick :cherries:
         inherit_labels: false
-        cherry-pick-branch: "${{ inputs.original-pr-branch }}_${{ inputs.target-branch }}"
+        cherry-pick-branch: "${{ inputs.target-branch }}_${{ inputs.original-pr-branch }}"
         reviewers: ${{ env.BACKPORT_REVIEWERS }}

--- a/.ci/actions/parse-labels/action.yml
+++ b/.ci/actions/parse-labels/action.yml
@@ -24,7 +24,7 @@ runs:
       run: |
         echo "Labels retrieved below"
         echo "${{ inputs.labels }}"
-        filtered_labels="$(echo $LABELS | jq -c 'map(select(.name | startswith("${{ inputs.label-prefix }}")))')"
+        filtered_labels="$(echo ${{ inputs.labels }} | jq -c 'map(select(.name | startswith("${{ inputs.label-prefix }}")))')"
         echo "filtered_labels = ${filtered_labels}"
         echo "FILTERED_LABELS=${filtered_labels}" >> $GITHUB_ENV
 

--- a/.ci/actions/parse-labels/action.yml
+++ b/.ci/actions/parse-labels/action.yml
@@ -1,0 +1,40 @@
+name: 'Parse Labels'
+description: 'Extract target branches or refs from labels'
+
+inputs:
+  labels:
+    description: "List of label objects to be parsed, e.g., github.event.pull_request.labels"
+    required: true
+  label-prefix:
+    description: "Extract targets from labels matching this provided prefix"
+    default: "backport-"
+    required: false
+
+outputs:
+  targets:
+    description: "Extracted targets"
+    value: ${{ steps.extract-targets.outputs.targets }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Fetch labels
+      id: fetch-labels
+      shell: bash
+      run: |
+        echo "Labels retrieved below"
+        echo "${{ inputs.labels }}"
+        filtered_labels="$(echo $LABELS | jq -c 'map(select(.name | startswith("${{ inputs.label-prefix }}")))')"
+        echo "filtered_labels = ${filtered_labels}"
+        echo "FILTERED_LABELS=${filtered_labels}" >> $GITHUB_ENV
+
+    - name: Extract targets
+      id: extract-targets
+      shell: bash
+      run: |
+        targets="$(echo $FILTERED_LABELS | jq -c '[.[] | .name | sub("${{ inputs.label-prefix }}"; "")]')"
+        echo "::set-output name=targets::$(echo $targets)" 
+    
+    - name: Printing extracted targets
+      shell: bash
+      run: echo "Extracted target branches ${{ steps.extract-targets.outputs.targets }}"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -51,3 +51,19 @@ How to retest this PR or trigger a specific build:
 
 * <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
 </details>
+
+<details>
+<summary>
+How to backport a pull request to a different branch?
+</summary>
+
+In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).
+
+> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.
+
+Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.
+
+If something goes wrong, the author will be notified and at this point a manual backporting is needed.
+
+> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
+</details>

--- a/.github/workflows/pr-backporting.yml
+++ b/.github/workflows/pr-backporting.yml
@@ -15,10 +15,14 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       target-branches: ${{ steps.set-targets.outputs.targets }}
+    env:
+      LABELS: ${{ toJSON(github.event.pull_request.labels) }}
     steps:
       - name: Set target branches
         id: set-targets
         uses: kiegroup/droolsjbpm-build-bootstrap/.ci/actions/parse-labels@main
+        with:
+          labels: ${LABELS}
   
   backporting:
     if: ${{ github.event.pull_request.state == 'closed' && github.event.pull_request.merged && needs.compute-targets.outputs.target-branches != '[]' }}
@@ -29,8 +33,11 @@ jobs:
       matrix: 
         target-branch: ${{ fromJSON(needs.compute-targets.outputs.target-branches) }}
       fail-fast: true
+    env:
+      REVIEWERS: ${{ toJSON(github.event.pull_request.requested_reviewers) }}
     steps:
       - name: Backporting
         uses: kiegroup/droolsjbpm-build-bootstrap/.ci/actions/backporting@main
         with:
           target-branch: ${{ matrix.target-branch }}
+          additional-reviewers: ${REVIEWERS}

--- a/.github/workflows/pr-backporting.yml
+++ b/.github/workflows/pr-backporting.yml
@@ -2,7 +2,7 @@ name: Pull Request Backporting
 
 on:
   pull_request_target:
-    types: [closed]
+    types: [closed, labeled]
     branches:
       - main
 

--- a/.github/workflows/pr-backporting.yml
+++ b/.github/workflows/pr-backporting.yml
@@ -1,0 +1,36 @@
+name: Pull Request Backporting
+
+on:
+  pull_request_target:
+    types: [closed]
+    branches:
+      - main
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  compute-targets:
+    if: ${{ github.event.pull_request.state == 'closed' && github.event.pull_request.merged }}
+    runs-on: ubuntu-latest
+    outputs:
+      target-branches: ${{ steps.set-targets.outputs.targets }}
+    steps:
+      - name: Set target branches
+        id: set-targets
+        uses: kiegroup/droolsjbpm-build-bootstrap/.ci/actions/parse-labels@main
+  
+  backporting:
+    if: ${{ github.event.pull_request.state == 'closed' && github.event.pull_request.merged && needs.compute-targets.outputs.target-branches != '[]' }}
+    name: "[${{ matrix.target-branch }}] - Backporting"
+    runs-on: ubuntu-latest
+    needs: compute-targets
+    strategy:
+      matrix: 
+        target-branch: ${{ fromJSON(needs.compute-targets.outputs.target-branches) }}
+      fail-fast: true
+    steps:
+      - name: Backporting
+        uses: kiegroup/droolsjbpm-build-bootstrap/.ci/actions/backporting@main
+        with:
+          target-branch: ${{ matrix.target-branch }}


### PR DESCRIPTION
**Thank you for submitting this pull request**

**JIRA**: 

https://issues.redhat.com/browse/BXMSPROD-1892

**referenced Pull Requests**:

* https://github.com/carloscastrojumo/github-cherry-pick-action/pull/26
* https://github.com/kiegroup/kogito-pipelines/pull/743

**Workflows PRs**:
- https://github.com/kiegroup/appformer/pull/1370
- https://github.com/kiegroup/droolsjbpm-integration/pull/2919
- https://github.com/kiegroup/droolsjbpm-knowledge/pull/633
- https://github.com/kiegroup/drools-wb/pull/1564
- https://github.com/kiegroup/jbpm/pull/2251
- https://github.com/kiegroup/jbpm-wb/pull/1581
- https://github.com/kiegroup/jbpm-work-items/pull/272
- https://github.com/kiegroup/kie-docs/pull/4380
- https://github.com/kiegroup/kie-jpmml-integration/pull/75
- https://github.com/kiegroup/kie-soup/pull/262
- https://github.com/kiegroup/kie-wb-common/pull/3795
- https://github.com/kiegroup/kie-wb-distributions/pull/1211
- https://github.com/kiegroup/kie-wb-playground/pull/131
- https://github.com/kiegroup/lienzo-core/pull/181
- https://github.com/kiegroup/lienzo-tests/pull/144
- https://github.com/kiegroup/optaplanner-wb/pull/422
- https://github.com/kiegroup/process-migration-service/pull/107

**Improvements**:

Created two reusable actions:
- _backporting_: this action applies the cherry-pick and creates one or more pull requests in according to their inputs
- _parse-labels_: parse pull request labels extracting target branches

Created a workflow that calls previous actions and create backporting pull requests whenever a pull request (having one or more labels `backport-<branch>`) is successfully merged.

> **Note**: once we agree I will copy and paste this `pr-backporting.yml` workflow on every repository for which we want to provide this functionality.

You can check Kiegroup organization repositories CI status from [Chain Status webpage](https://kiegroup.github.io/droolsjbpm-build-bootstrap/)

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used locally on command line or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it. 

A general local execution could be the following one, where the tool clones all dependent projects starting from the `-sp` one and it locally applies the pull request (if it exists) in order to reproduce a complete build scenario for the provided *Pull Request*.

> **Note:** the tool considers multiple *Pull Requests* related to each other if their branches (generally in the forked repositories) have the same name.

``` shell
$ build-chain-action -df 'https://raw.githubusercontent.com/${GROUP:kiegroup}/droolsjbpm-build-bootstrap/${BRANCH:main}/.ci/pull-request-config.yaml' build pr -url <pull-request-url> -sp kiegroup/kie-wb-distributions [--skipExecution]
```

> Consider changing `kiegroup/kie-wb-distributions` with the correct starting project.


</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest</b> (using <i>this</i> e.g. <b>Jenkins retest this</b> optional but no longer required)
 
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
    
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
