### PR TITLE
[BXMSPROD-1936] Fix default reviewers and customization

### DIFF
--- a/.ci/actions/backporting/action.yml
+++ b/.ci/actions/backporting/action.yml
@@ -25,10 +25,21 @@ inputs:
     description: "Author of the original pull request"
     default: "${{ github.event.pull_request.user.login }}"
     required: false
-  additional-reviewers:
-    description: "Additional backported pull request reviewers, e.g., toJSON(github.event.pull_request.requested_reviewers)"
-    default: "[]"
+  include-merge-as-reviewer:
+    description: "Whether include or not who merged the pull request as reviewer of the backported one"
+    default: "true"
     required: false
+  include-requested-reviewers:
+    description: "Whether include or not original requested reviewers"
+    default: "true"
+    required: false
+  custom-reviewers:
+    description: "Comma separated list of additional reviewers to be added in backported pull request"
+    required: false
+  additional-reviewers:
+    description: "Additional backported pull request reviewers, default is toJSON(github.event.pull_request.requested_reviewers)"
+    required: false
+    deprecationMessage: "[IGNORED] The previous default is managed by `include-requested-reviewers`. If you want to add more custom reviewers use `custom-reviewers` input instead"
 
 runs: 
   using: 'composite'
@@ -37,18 +48,46 @@ runs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
+    - name: Setup default values
+      shell: bash
+      env:
+        REQUESTED_REVIEWERS: ${{ toJSON(github.event.pull_request.requested_reviewers) }}
+        MERGED_BY: ${{ github.event.pull_request.merged_by.login }}
+        CUSTOM_REVIEWERS: ""
+      run: |
+        # -- Additional Reviewers --
+        # trick to save multiline string as env variable
+        echo "REQUESTED_REVIEWERS<<EOF" >> $GITHUB_ENV
+        input_include_requested_revs=${{ inputs.include-requested-reviewers }}
+        [[ "$input_include_requested_revs" == "true" ]] && echo "$REQUESTED_REVIEWERS" >> $GITHUB_ENV || echo "[]" >> $GITHUB_ENV
+        echo "EOF" >> $GITHUB_ENV
+
+        # -- Custom Reviewers --
+        input_custom_revs=${{ inputs.custom-reviewers }}
+        [[ ! -z "$input_custom_revs" ]] \
+          && echo "CUSTOM_REVIEWERS=$(echo "[\"${input_custom_revs/,/\",\"}\"]")" >> $GITHUB_ENV \
+          || echo "CUSTOM_REVIEWERS=[]" >> $GITHUB_ENV
+
+        # -- Merged By Reviewer --
+        input_include_merge=${{ inputs.include-merge-as-reviewer }}
+        [[ "$input_include_merge" == "true" ]] && echo "MERGED_BY=$MERGED_BY" >> $GITHUB_ENV || echo "MERGED_BY=" >> $GITHUB_ENV
     - name: Prepare reviewers
       id: prepare-reviewers
       shell: bash
       run: |
-        echo "Additional reviewers retrieved below"
-        echo "${{ inputs.additional-reviewers }}"
-        reviewers="$(echo ${{ inputs.additional-reviewers }} | jq -c 'map(.login)' | jq -cr '. |= . + ["${{ inputs.author }}"] | unique | join(",")')"
+        env
+
+        # starts from request reviewers or empty array
+        reviewers="$(echo ${REQUESTED_REVIEWERS:-[]} | jq -c 'map(.login)' | jq -cr '[. |= . + ["${{ inputs.author }}", "${{ env.MERGED_BY }}"] | .[] | select(length > 0)] | unique')"
+
+        # add custom reviewers, if any
+        reviewers="$(jq -cr --argjson arr1 "$reviewers" --argjson arr2 "${CUSTOM_REVIEWERS:-[]}" -n '$arr1 + $arr2 | unique | join(",")')"
+
         echo "reviewers = ${reviewers}"
         echo "BACKPORT_REVIEWERS=${reviewers}" >> $GITHUB_ENV
     - name: Perform cherry pick
       id: cherry-pick
-      uses: carloscastrojumo/github-cherry-pick-action@v1.0.5
+      uses: carloscastrojumo/github-cherry-pick-action@v1.0.6
       with:
         branch: "${{ inputs.target-branch }}"
         title: "[${{ inputs.target-branch }}] ${{ inputs.title }}"

--- a/.github/workflows/pr-backporting.yml
+++ b/.github/workflows/pr-backporting.yml
@@ -33,11 +33,8 @@ jobs:
       matrix: 
         target-branch: ${{ fromJSON(needs.compute-targets.outputs.target-branches) }}
       fail-fast: true
-    env:
-      REVIEWERS: ${{ toJSON(github.event.pull_request.requested_reviewers) }}
     steps:
       - name: Backporting
         uses: kiegroup/droolsjbpm-build-bootstrap/.ci/actions/backporting@main
         with:
           target-branch: ${{ matrix.target-branch }}
-          additional-reviewers: ${REVIEWERS}


### PR DESCRIPTION
**Thank you for submitting this pull request**

**JIRA**: https://issues.redhat.com/browse/BXMSPROD-1936

**referenced Pull Requests**:

* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/2175
* https://github.com/kiegroup/kogito-pipelines/pull/752

**Improvements**

Added new input parameters:
* `include-merge-as-reviewer`: whether to include or not the user who merged the PR as reviewer, default `true`
* `include-requested-reviewers`: whether to include original requested reviewers into backported pr, notice that approved reviewers are not in this list since ti seems github remove them. Default `true`
* `custom-reviewers`: allows users to customize the workflow adding additional custom reviewers

Deprecated `additional-reviewers` as it is now managed internally in the composite actions itself, this field will be ignored since now.

Thus we can remove that parameter from any workflow without changing the final result as `include-requested-reviewers` is set to true by default.

You can check Kiegroup organization repositories CI status from [Chain Status webpage](https://kiegroup.github.io/droolsjbpm-build-bootstrap/)

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used locally on command line or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it. 

A general local execution could be the following one, where the tool clones all dependent projects starting from the `-sp` one and it locally applies the pull request (if it exists) in order to reproduce a complete build scenario for the provided *Pull Request*.

> **Note:** the tool considers multiple *Pull Requests* related to each other if their branches (generally in the forked repositories) have the same name.

``` shell
$ build-chain-action -df 'https://raw.githubusercontent.com/${GROUP:kiegroup}/droolsjbpm-build-bootstrap/${BRANCH:main}/.ci/pull-request-config.yaml' build pr -url <pull-request-url> -sp kiegroup/kie-wb-distributions [--skipExecution]
```

> Consider changing `kiegroup/kie-wb-distributions` with the correct starting project.


</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest</b> (using <i>this</i> e.g. <b>Jenkins retest this</b> optional but no longer required)
 
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
    
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

* <b>for windows-specific os job</b> add the label `windows_check`
</details>

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>
