### PR TITLE
Fix directory name in which we want to run sonar analysis

### DIFF
--- a/.ci/jenkins/Jenkinsfile.buildchain
+++ b/.ci/jenkins/Jenkinsfile.buildchain
@@ -110,7 +110,7 @@ pipeline {
                         def project = util.getProjectTriggeringJob()[1]
                         if(["optaplanner", "drools", "appformer", "jbpm", "drools-wb", "kie-soup", "droolsjbpm-integration", "kie-wb-common"].contains(project))
                         {
-                            dir("bc/kiegroup_${project.replaceAll("-", "_")}") {
+                            dir("bc/kiegroup_${project}") {
                                 maven.runMavenWithSettingsSonar("771ff52a-a8b4-40e6-9b22-d54c7314aa1e", "-nsu generate-resources -Psonarcloud-analysis -Denforcer.skip=true", "SONARCLOUD_TOKEN", "sonar_analysis.maven.log")
                             }
                         } else {


### PR DESCRIPTION
The naming convention of the cloned folder is `<owner>_<repository>`. So for example instead of `kiegroup_droolsjbpm_integration` we need `kiegroup_droolsjbpm-integration`