### PR TITLE
optaplanner and drools 7.x binaries are not any more needed to upload…

### DIFF
--- a/.ci/jenkins/Jenkinsfile.release
+++ b/.ci/jenkins/Jenkinsfile.release
@@ -30,7 +30,7 @@ pipeline {
         timestamps()
     }
     tools {
-        nodejs 'nodejs-12.16.3'
+        nodejs 'nodejs-16.2.0'
         maven mvnTool
         jdk jdkVersion
     }
@@ -385,34 +385,12 @@ pipeline {
                 }
             }
         }
-        stage('Drools binaries upload'){
-            steps{
-                script {
-                    execute {
-                        sshagent(['drools-filemgmt']) {
-                            sh './script/release/10a_drools_upload_filemgmt.sh'
-                        }
-                    }
-                }
-            }
-        }
         stage('Jbpm binaries upload'){
             steps{
                 script {
                     execute {
                         sshagent(['jbpm-filemgmt']) {
                             sh './script/release/10b_jbpm_upload_filemgmt.sh'
-                        }
-                    }
-                }
-            }
-        }
-        stage('Optaplanner binaries upload'){
-            steps{
-                script {
-                    execute {
-                        sshagent(['optaplanner-filemgmt']) {
-                            sh './script/release/10c_optaplanner_upload_filemgmt.sh'
                         }
                     }
                 }

--- a/.ci/release-config.yaml
+++ b/.ci/release-config.yaml
@@ -15,9 +15,6 @@ build:
   - project: kiegroup/jbpm-work-items
     build-command:
       current: ${{ env.MAVEN_COMMAND }}
-  - project: kiegroup/optaplanner
-    build-command:
-      current: ${{ env.MAVEN_COMMAND }}
   - project: kiegroup/kie-docs
     build-command:
       current: ${{ env.MAVEN_COMMAND }}

--- a/script/release/prepareUploadDir.sh
+++ b/script/release/prepareUploadDir.sh
@@ -8,12 +8,6 @@ deployDir=../community-deploy-dir
 mkdir ${kieVersion}_uploadBinaries
 cd ${kieVersion}_uploadBinaries
 
-# docs
-mkdir drools-docs
-cp  $deployDir/org/drools/drools-docs/$kieVersion/drools-docs-$kieVersion.zip drools-docs/
-unzip drools-docs/drools-docs-$kieVersion.zip -d drools-docs/
-rm drools-docs/drools-docs-$kieVersion.zip
-
 mkdir kie-api-javadoc
 scp  $deployDir/org/kie/kie-api/$kieVersion/kie-api-$kieVersion-javadoc.jar kie-api-javadoc/
 unzip kie-api-javadoc/kie-api-$kieVersion-javadoc.jar -d kie-api-javadoc/
@@ -24,29 +18,11 @@ cp  $deployDir/org/jbpm/jbpm-docs/$kieVersion/jbpm-docs-$kieVersion.zip jbpm-doc
 unzip jbpm-docs/jbpm-docs-$kieVersion.zip -d jbpm-docs/
 rm jbpm-docs/jbpm-docs-$kieVersion.zip
 
-mkdir optaplanner-docs
-cp  $deployDir/org/optaplanner/optaplanner-docs/$kieVersion/optaplanner-docs-$kieVersion.zip optaplanner-docs/
-unzip optaplanner-docs/optaplanner-docs-$kieVersion.zip -d optaplanner-docs/
-rm optaplanner-docs/optaplanner-docs-$kieVersion.zip
-
-# drools
-cp $deployDir/org/drools/drools-distribution/$kieVersion/drools-distribution-$kieVersion.zip .
-cp $deployDir/org/drools/droolsjbpm-integration-distribution/$kieVersion/droolsjbpm-integration-distribution-$kieVersion.zip .
-cp $deployDir/org/kie/business-central/$kieVersion/business-central-$kieVersion-*.war .
-cp $deployDir/org/kie/server/kie-server-distribution/$kieVersion/kie-server-distribution-$kieVersion.zip .
-
 # jbpm
 cp $deployDir/org/jbpm/jbpm-distribution/$kieVersion/jbpm-distribution-$kieVersion-bin.zip jbpm-$kieVersion-bin.zip
 cp $deployDir/org/jbpm/jbpm-distribution/$kieVersion/jbpm-distribution-$kieVersion-examples.zip jbpm-$kieVersion-examples.zip
 cp $deployDir/org/kie/jbpm-server-distribution/$kieVersion/jbpm-server-distribution-$kieVersion-dist.zip jbpm-server-$kieVersion-dist.zip
 
-# optaplanner
-cp $deployDir/org/optaplanner/optaplanner-distribution/$kieVersion/optaplanner-distribution-$kieVersion.zip .
-
 # copies binaries + docs that are only available in /target directories - they are not deployed
 mkdir service-repository
 cp -r ../bc/kiegroup_jbpm_work_items/repository/target/repository-$kieVersion/* service-repository
-mkdir optaplanner-javadoc
-cp -r ../bc/kiegroup_optaplanner/optaplanner-distribution/target/optaplanner-distribution-$kieVersion/optaplanner-distribution-$kieVersion/javadocs/* optaplanner-javadoc
-mkdir optaplanner-wb-es-docs
-cp -r ../bc/kiegroup_kie_docs/doc-content/optaplanner-wb-es-docs/target/generated-docs/* optaplanner-wb-es-docs


### PR DESCRIPTION
… to the web

optaplanner and drools excluded from upload

upgrade nodejs version

**Thank you for submitting this pull request**

**JIRA**: _(please edit the JIRA link if it exists)_ 

[link](https://www.example.com)

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* paste the link(s) from GitHub here
* link 2
* link 3 etc.

You can check Kiegroup organization repositories CI status from [Chain Status webpage](https://kiegroup.github.io/droolsjbpm-build-bootstrap/)

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used locally on command line or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it. 

A general local execution could be the following one, where the tool clones all dependent projects starting from the `-sp` one and it locally applies the pull request (if it exists) in order to reproduce a complete build scenario for the provided *Pull Request*.

> **Note:** the tool considers multiple *Pull Requests* related to each other if their branches (generally in the forked repositories) have the same name.

``` shell
$ build-chain-action -df 'https://raw.githubusercontent.com/${GROUP:kiegroup}/droolsjbpm-build-bootstrap/${BRANCH:main}/.ci/pull-request-config.yaml' build pr -url <pull-request-url> -sp kiegroup/kie-wb-distributions [--skipExecution]
```

> Consider changing `kiegroup/kie-wb-distributions` with the correct starting project.


</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest</b> (using <i>this</i> e.g. <b>Jenkins retest this</b> optional but no longer required)
 
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
    
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

* <b>for windows-specific os job</b> add the label `windows_check`
</details>

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>
