### PR TITLE
[RHPAM-4683] Revert "RHPAM-4631 apache cxf to 3.5.5" to 3.4.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -313,7 +313,7 @@
     <version.com.google.testing.compile>0.11</version.com.google.testing.compile>
     <version.org.antlr4>4.9.2</version.org.antlr4>
     <!-- CXF's version is aligned with Jetty -->
-    <version.org.apache.cxf>3.5.5</version.org.apache.cxf>
+    <version.org.apache.cxf>3.4.10</version.org.apache.cxf>
     <version.org.apache.camel>2.24.0</version.org.apache.camel>
     <version.org.codehaus.cargo>1.9.3</version.org.codehaus.cargo>
     <version.org.freemarker>2.3.30</version.org.freemarker>


### PR DESCRIPTION
Reverts kiegroup/droolsjbpm-build-bootstrap#2180

solves https://issues.redhat.com/browse/RHPAM-4683