### PR TITLE
for 7.74.0.Final: fixed split of org.kie

### DIFF
--- a/.ci/jenkins/Jenkinsfile.release
+++ b/.ci/jenkins/Jenkinsfile.release
@@ -65,9 +65,9 @@ pipeline {
                          env.R_BRANCH_EXIST = sh(script: "git ls-remote --heads https://github.com/${ghOrgUnit}/droolsjbpm-build-bootstrap ${releaseBranch} | wc -l", returnStdout: true).trim()
                          echo "R_BRANCH_EXIST: ${env.R_BRANCH_EXIST}"
                          if ( "${env.R_BRANCH_EXIST}" == "1" ) {
-                             echo "release branch exists"
+                            echo "release branch exists"
                          } else {
-                             echo "release branch does not yes exist"
+                            echo "release branch does not yes exist"
                          }
                      }
                  }
@@ -145,7 +145,7 @@ pipeline {
                 and assign tasks to people who should run these checks (if not done yet)
 
 
-                Thank you""", subject: "start of community-release ${kieVersion}", to: "bsig@redhat.com etirelli@redhat.com lazarotti@redhat.com dward@redhat.com dgutierr@redhat.com aparedes@redhat.com doliver@redhat.com"
+                Thank you""", subject: "start of community-release ${kieVersion}", to: "mbiarnes@redhat.com mnovotny@redhat.com lazarotti@redhat.com dgutierr@redhat.com aparedes@redhat.com doliver@redhat.com"
             }
         }
         stage('Build projects') {
@@ -185,7 +185,7 @@ pipeline {
 
                 Please look here: ${BUILD_URL}consoleText
 
-                LOG: attached""", subject: "community-release ${kieVersion} failed", to: "bsig@redhat.com", attachLog:true
+                LOG: attached""", subject: "community-release ${kieVersion} failed", to: "mbiarnes@redhat.com mnovotny@redhat.com", attachLog:true
             }
         }
         // create a local directory for archiving artifacts
@@ -229,11 +229,12 @@ pipeline {
                             script {
                                 env.repoID = sh(script: """curl --header 'Content-Type: application/xml' -X POST -u $CREDS --data "<promoteRequest><data><description>kie-${kieVersion}</description></data></promoteRequest>" -v https://repository.jboss.org/nexus/service/local/staging/profiles/15c58a1abc895b/start -H "Connection: close" | grep -oP '(?<=stagedRepositoryId>).*[0-9]' """, returnStdout: true).trim()
                                 echo "repoID: ${repoID}"
-                                def repositories=['dashbuilder', 'drools', 'kie', 'jbpm', 'uberfire']
+                                def repositories=['dashbuilder', 'drools', 'jbpm', 'uberfire']
                                 repositories.each{ repo ->
                                     sh "zip -qr ${repo}.zip org/${repo}"
                                     sh """curl --silent --upload-file ${repo}.zip -u \$CREDS -v https://repository.jboss.org/nexus/service/local/repositories/\$repoID/content-compressed -H "Connection: keep-alive" -H "Keep-Alive: timeout=1800000, max=0" """
                                 }
+                                /* org.kie has to be split */
                                 sh "sh $WORKSPACE/script/release/12_splitOrgKie.sh"
                                 sh """curl --header "Content-Type: application/xml" -X POST -u \$CREDS --data "<promoteRequest><data><stagedRepositoryId>${repoID}</stagedRepositoryId><description>kie-${kieVersion}</description></data></promoteRequest>" -v https://repository.jboss.org/nexus/service/local/staging/profiles/15c58a1abc895b/finish -H "Connection: close" """
                             }
@@ -247,20 +248,20 @@ pipeline {
                 expression { runBuild == 'YES'}
             }
             steps {
-		        withCredentials([usernameColonPassword(credentialsId: 'kie_upload_Nexus', variable: 'CREDS')]) {
-    		        script{
-				        env.STAGING_STATUS = ""
-				        counter=0
-				        while( "${env.STAGING_STATUS}" != "closed" ){
-    				        env.STAGING_STATUS = sh(script: """ curl -u $CREDS -H 'Accept: application/json' -H 'Content-Type: application/json' https://repository.jboss.org/nexus/service/local/staging/profile_repositories/15c58a1abc895b | grep -oP '$repoID\",\"type\":\"\\K[^\"]+(?=\")' """, returnStdout: true).trim()
-    				        echo "staging-repository is still ${STAGING_STATUS}"
-    				        sleep(60*15)
-    				        counter=counter+1
-    				        echo "counter: $counter"
-				        }
-				        echo "staging-repository is ${STAGING_STATUS} now"
-		            }
-	            }
+                withCredentials([usernameColonPassword(credentialsId: 'kie_upload_Nexus', variable: 'CREDS')]) {
+                    script{
+                        env.STAGING_STATUS = ''
+                        counter=0
+                        while( "${env.STAGING_STATUS}" != "closed" ){
+                            env.STAGING_STATUS = sh(script: """ curl -u $CREDS -H 'Accept: application/json' -H 'Content-Type: application/json' https://repository.jboss.org/nexus/service/local/staging/profile_repositories/15c58a1abc895b | grep -oP '$repoID\",\"type\":\"\\K[^\"]+(?=\")' """, returnStdout: true).trim()
+                            echo "staging-repository is still ${STAGING_STATUS}"
+                            sleep(60*15)
+                            counter=counter+1
+                            echo "counter: $counter"
+                        }
+                        echo "staging-repository is ${STAGING_STATUS} now"
+                    }
+                }
             }
         }
         stage('Additional tests for community') {
@@ -306,7 +307,7 @@ pipeline {
                 sanity checks: https://docs.google.com/spreadsheets/d/1jPtRilvcOji__qN0QmVoXw6KSi4Nkq8Nz_coKIVfX6A/edit#gid=167259416
                 In case Sanity Checks were already done and this kind of mail arrives the second time, please verify if the bugs reported in Sanity Checks are fixed now.
 
-                Component version: KIE version =  ${kieVersion}""", subject: "build for community-release ${kieVersion}: ${currentBuild.currentResult}", to: "bsig@redhat.com"
+                Component version: KIE version =  ${kieVersion}""", subject: "build for community-release ${kieVersion}: ${currentBuild.currentResult}", to: "mbiarnes@redhat.com mnovotny@redhat.com"
             }
         }
         // user interaction required: continue or abort
@@ -341,7 +342,7 @@ pipeline {
                 business-monitoring-webapp: https://repository.jboss.org/nexus/content/groups/public-jboss/org/kie/business-monitoring-webapp/${kieVersion}/
                 jbpm-server-distribution (single zip): https://repository.jboss.org/nexus/content/groups/public-jboss/org/kie/jbpm-server-distribution/${kieVersion}/
 
-                Component version: KIE Version = ${kieVersion}""", subject: "community-release ${kieVersion} was released", to: "bsig@redhat.com"
+                Component version: KIE Version = ${kieVersion}""", subject: "community-release ${kieVersion} was released", to: "mbiarnes@redhat.com mnovotny@redhat.com"
             }
         }
         // if the pipeline job was executed again but without building, the binaries uploaded to filemgmt.jboss.org are needed


### PR DESCRIPTION
changed email recipients

**Thank you for submitting this pull request**

**JIRA**: _(please edit the JIRA link if it exists)_ 

[link](https://www.example.com)

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* paste the link(s) from GitHub here
* link 2
* link 3 etc.

You can check Kiegroup organization repositories CI status from [Chain Status webpage](https://kiegroup.github.io/droolsjbpm-build-bootstrap/)

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used locally on command line or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it. 

A general local execution could be the following one, where the tool clones all dependent projects starting from the `-sp` one and it locally applies the pull request (if it exists) in order to reproduce a complete build scenario for the provided *Pull Request*.

> **Note:** the tool considers multiple *Pull Requests* related to each other if their branches (generally in the forked repositories) have the same name.

``` shell
$ build-chain-action -df 'https://raw.githubusercontent.com/${GROUP:kiegroup}/droolsjbpm-build-bootstrap/${BRANCH:main}/.ci/pull-request-config.yaml' build pr -url <pull-request-url> -sp kiegroup/kie-wb-distributions [--skipExecution]
```

> Consider changing `kiegroup/kie-wb-distributions` with the correct starting project.


</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest</b> (using <i>this</i> e.g. <b>Jenkins retest this</b> optional but no longer required)
 
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
    
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

* <b>for windows-specific os job</b> add the label `windows_check`
</details>

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>
