### PR TITLE
BXMSPROD-2080: update version adapted to build-chain logic

### DIFF
--- a/.ci/daily-config.yaml
+++ b/.ci/daily-config.yaml
@@ -3,26 +3,16 @@ version: "2.1"
 dependencies: ./project-dependencies.yaml
 
 pre: |
-  export MAVEN_COMMAND=mvn -B -e -U clean deploy -Dfull -Drelease -DaltDeploymentRepository=local::default::file://${{ env.WORKSPACE }}/deploy-dir -Dmaven.test.redirectTestOutputToFile=true -Dmaven.test.failure.ignore=true -Dgwt.memory.settings="-Xmx10g" -Prun-code-coverage -Dcontainer.profile=wildfly -Dcontainer=wildfly -Dintegration-tests=true -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3
-  echo "MAVEN_COMMAND=" ${{ env.MAVEN_COMMAND }}
-  echo "WORKSPACE=" ${{ env.WORKSPACE }}
   java -version
+  export MAVEN_COMMAND=mvn -B -e -U clean deploy -Dfull -Drelease -DaltDeploymentRepository=local::default::file://${{ env.WORKSPACE }}/deploy-dir -Dmaven.test.redirectTestOutputToFile=true -Dmaven.test.failure.ignore=true -Dgwt.memory.settings="-Xmx10g" -Prun-code-coverage -Dcontainer.profile=wildfly -Dcontainer=wildfly -Dintegration-tests=true -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3
 
 default:
   build-command:
     current: |
+      ${{ env.WORKSPACE }}/bc/kiegroup_droolsjbpm-build-bootstrap/script/release/update-versions-build-chain.sh ${{ env.KIE_VERSION }}
       ${{ env.MAVEN_COMMAND }}
       ${{ env.WORKSPACE }}/clean-up.sh `pwd`
-
 build:
-  - project: kiegroup/lienzo-core
-    build-command:
-      before:
-        current: |
-          ${{ env.WORKSPACE }}/bc/kiegroup_droolsjbpm-build-bootstrap/script/release/update-versions-build-chain.sh ${{ env.KIE_VERSION }} community
-      current: |
-        ${{ env.MAVEN_COMMAND }}
-        ${{ env.WORKSPACE }}/clean-up.sh `pwd`
   - project: kiegroup/process-migration-service
     build-command:
       current: echo 'skip'

--- a/.ci/jenkins/Jenkinsfile.daily
+++ b/.ci/jenkins/Jenkinsfile.daily
@@ -24,7 +24,7 @@ pipeline {
         jdk jdkVersion
     }
     options {
-        timestamps ()
+        timestamps()
     }
     environment {
         FIREFOX_FOLDER = '/opt/tools/firefox-91esr'
@@ -109,7 +109,7 @@ pipeline {
         stage('Deploy process-migration-service locally with jdk11'){
             when {
                 expression { (jdkVersion == 'kie-jdk11.0.15') }
-            }    
+            }
             steps {
                 dir("${WORKSPACE}/bc/kiegroup_process-migration-service") {
                     configFileProvider([configFile(fileId: '771ff52a-a8b4-40e6-9b22-d54c7314aa1e', targetLocation: 'jenkins-settings.xml', variable: 'SETTINGS_XML_FILE')]) {
@@ -117,14 +117,14 @@ pipeline {
                     }
                 }
             }
-        }        
+        }
         stage('check space after build') {
             steps {
                 script{
                     util.spaceLeft()
                 }
             }
-        }         
+        }
         stage('Unpack zip of artifacts to QA Nexus') {
             when {
                 expression { (jdkVersion == 'kie-jdk11.0.15' || jdkVersion == 'kie-jdk1.8') && additionalMavenFlag != '-Dproductized' }
@@ -158,9 +158,9 @@ pipeline {
                     "kieServerMatrix" : {
                         build job: "kieServerMatrix", propagate: false, parameters: [[$class: 'StringParameterValue', name: 'kieVersion', value: kieVersion], [$class: 'StringParameterValue', name: 'baseBranch', value: baseBranch]]
                     }
-                )    
-            } 
-        } 
+                )
+            }
+        }
     }
     post {
         always {
@@ -170,7 +170,7 @@ pipeline {
             }
             cleanWs()
         }
-    }      
+    }
 }
 
 void sendNotification() {

--- a/.ci/update-versions-release.yaml
+++ b/.ci/update-versions-release.yaml
@@ -6,29 +6,24 @@ pre: |
   export COMMIT_COMMAND=git commit -am ${{ env.COM_MSG }}
   export CREATE_COMMAND=git checkout -b ${{ env.R_BRANCH }}
   export PUSH_COMMAND=git push origin ${{ env.R_BRANCH }}
-  echo "COMMIT_COMMAND=" ${{ env.COMMIT_COMMAND }}
-  echo "CREATE_COMMAND=" ${{ env.CREATE_COMMAND }}
-  echo "PUSH_COMMAND=" ${{ env.PUSH_COMMAND }}
 default:
   build-command:
     current: |
-      ${{ env.COMMIT_COMMAND }}
       ${{ env.CREATE_COMMAND }}
+      ${{ env.WORKSPACE }}/bc/kiegroup_droolsjbpm-build-bootstrap/script/release/update-versions-build-chain.sh ${{ env.KIE_VERSION }}
+      ${{ env.COMMIT_COMMAND }}
       ${{ env.PUSH_COMMAND }}
 build:
   - project: kiegroup/lienzo-core
     build-command:
       before:
-        current: |
-          echo "RELEASE_BRANCH= " ${{ env.R_BRANCH }}
-          echo "BASE_BRANCH= " ${{ env.B_BRANCH }}
-          echo "R_BRANCH_EXIST= " ${{ env.R_BRANCH_EXIST }}
-          echo "CHECKOUT_BRANCH= " ${{ env.CHECKOUT_BRANCH }}
+        current:
           ${{ env.WORKSPACE }}/bc/kiegroup_droolsjbpm-build-bootstrap/script/release/eraseM2.sh ${{ env.MAVEN_DIR }}
-          ${{ env.WORKSPACE }}/bc/kiegroup_droolsjbpm-build-bootstrap/script/release/update-versions-build-chain.sh ${{ env.KIE_VERSION }} community
+  - project: kiegroup/kie-docs
+    build-command:
       current: |
-        ${{ env.COMMIT_COMMAND }}
         ${{ env.CREATE_COMMAND }}
+        ${{ env.WORKSPACE }}/bc/kiegroup_droolsjbpm-build-bootstrap/script/release/updateVersionsBuildChain.sh ${{ env.KIE_VERSION }}
+        ${{ env.COMMIT_COMMAND }}
         ${{ env.PUSH_COMMAND }}
-
 

--- a/script/release/update-versions-build-chain.sh
+++ b/script/release/update-versions-build-chain.sh
@@ -1,46 +1,20 @@
 #!/bin/bash
 set -e
 
-# IMPORTANT: if you want the script to use a custom settings.xml instead of a predefined (community or productized)
-# set the variable SETTINGS_XML_FILE with the full path to your settings.xml like
-#
-# export SETTINGS_XML_FILE="<full path>/settings.xml"
-#
-# and run the script > sh update-version-all.sh new_kieVersion custom.
+newVersion=$1
+repository=$(basename -s .git $(git config --get remote.origin.url))
 
-GROUP_ID=kiegroup
-echo "GROUP_ID: "$GROUP_ID
-
-# Updates the version for all kiegroup repositories
-
-initializeScriptDir() {
-    # Go to the script directory
-    cd `dirname $0`
-    # If the file itself is a symbolic link (ignoring parent directory links), then follow that link recursively
-    # Note that scriptDir=`pwd -P` does not do that and cannot cope with a link directly to the file
-    scriptFileBasename=`basename $0`
-    while [ -L "$scriptFileBasename" ] ; do
-        scriptFileBasename=`readlink $scriptFileBasename` # Follow the link
-        cd `dirname $scriptFileBasename`
-        scriptFileBasename=`basename $scriptFileBasename`
-    done
-    # Set script directory and remove other symbolic links (parent directory links)
-    scriptDir=`pwd -P`
-}
 
 mvnVersionsSet() {
-    mvn -B -N -e -s $settingsXmlFile versions:set -Dfull\
-      -DnewVersion="$newVersion" -DallowSnapshots=true -DgenerateBackupPoms=false
+    mvn -B -N -e versions:set -Dfull -DnewVersion="$newVersion" -DallowSnapshots=true -DgenerateBackupPoms=false
 }
 
 mvnVersionsUpdateParent() {
-    mvn -B -N -e -s $settingsXmlFile versions:update-parent -Dfull\
-     -DparentVersion="[$newVersion]" -DallowSnapshots=true -DgenerateBackupPoms=false
+    mvn -B -N -e versions:update-parent -Dfull -DparentVersion="[$newVersion]" -DallowSnapshots=true -DgenerateBackupPoms=false
 }
 
 mvnVersionsUpdateChildModules() {
-    mvn -B -N -e -s $settingsXmlFile versions:update-child-modules -Dfull\
-     -DallowSnapshots=true -DgenerateBackupPoms=false
+    mvn -B -N -e versions:update-child-modules -Dfull -DallowSnapshots=true -DgenerateBackupPoms=false
 }
 
 # Updates parent version and child modules versions for Maven project in current working dir
@@ -49,168 +23,66 @@ mvnVersionsUpdateParentAndChildModules() {
     mvnVersionsUpdateChildModules
 }
 
-initializeScriptDir
-droolsjbpmOrganizationDir="$scriptDir/../../.."
 
-if [ $# != 1 ] && [ $# != 2 ]; then
-    echo
-    echo "Usage:"
-    echo "  $0 newVersion releaseType"
-    echo "For example:"
-    echo "  $0 7.74.0.Final community"
-    echo
-    exit 1
-fi
+if [ "$repository" == "lienzo-core" ]; then
+    mvnVersionsSet
+    returnCode=$?
 
-newVersion=$1
-echo "New version is $newVersion"
+elif [ "$repository" == "lienzo-tests" ]; then
+    mvnVersionsSet
+    returnCode=$?
 
-releaseType=$2
-# check if the release type was set, if not default to "community"
-if [ "x$releaseType" == "x" ]; then
-    releaseType="community"
-fi
-
-
-if [ $releaseType == "community" ]; then
-    settingsXmlFile="$scriptDir/update-version-all-community-settings.xml"
-elif [ $releaseType == "productized" ]; then
-    settingsXmlFile="$scriptDir/update-version-all-productized-settings.xml"
-elif [ $releaseType == "custom" ]; then
-    settingsXmlFile="$SETTINGS_XML_FILE"
-else
-    echo "Incorrect release type specified: '$releaseType'. Supported values are 'community' or 'productized' or 'custom'"
-    exit 1
-fi
-echo "Specified release type: $releaseType"
-echo "Using following settings.xml: $settingsXmlFile"
-
-
-startDateTime=`date +%s`
-
-cd $droolsjbpmOrganizationDir
-
-# --- --- ---
-# Checks if repos in branched-7-repository-list.txt are on the right 7.x branch if all other repos are checked out to main.
-# For example, drools 7.x branch has the same version as main on other kiegroup/reps.
-for branch7xRepo in $(cat "${scriptDir}/../branched-7-repository-list.txt"); do
-  cd ${GROUP_ID}_$branch7xRepo
-  currentBranch=$(git rev-parse --abbrev-ref HEAD)
-  if [ $currentBranch == "main" ]; then
-      echo ""
-      echo "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
-    echo " Can't update versions for main branches because $branch7xRepo is still on main and should be checked out to 7.x"
-    echo ""
-      while true; do
-          echo "a abort"
-          echo "c continue and check out $branch7xRepo to 7.x"
-          echo ""
-          echo -n "Do you want to continue c or abort a "
-          echo ""
-          read choice
-
-          case $choice in
-              c)
-              git checkout 7.x
-              break
-              ;;
-              a)
-              echo "-------------------------- ABORTED --------------------------"
-              echo "+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
-              exit 0;
-              ;;
-              *)
-              echo "That is not a valid choice, try a c to continue or a to abort"
-              ;;
-          esac
-      done
-  fi
-  cd ..
-done
-# --- --- ---
-
-for repository in `cat ${scriptDir}/../repository-list.txt` ; do
-    echo
-
-    if [ ! -d $droolsjbpmOrganizationDir/${GROUP_ID}_$repository ]; then
-        echo "==============================================================================="
-        echo "Missing Repository: $repository. SKIPPING!"
-        echo "==============================================================================="
-    else
-        echo "==============================================================================="
-        echo "Repository: $repository"
-        echo "==============================================================================="
-        cd ${GROUP_ID}_$repository
-
-        if [ "$repository" == "lienzo-core" ]; then
-            mvnVersionsSet
-            returnCode=$?
-
-        elif [ "$repository" == "lienzo-tests" ]; then
-            mvnVersionsSet
-            returnCode=$?
-
-        elif [ "$repository" == "droolsjbpm-build-bootstrap" ]; then
-            # first build&install the current version (usually SNAPSHOT) as it is needed later by other repos
-            mvn -B -U -Dfull -s $settingsXmlFile clean install
-            # extract old kie version
-            kieOldVersion=$(grep -oP -m 2 '(?<=<version>).*(?=</version)' pom.xml| awk 'FNR==2')
-            mvnVersionsSet
-            # update latest released version property only for non-SNAPSHOT versions
-            if [[ ! $newVersion == *-SNAPSHOT ]]; then
-                sed -i "s/<latestReleasedVersionFromThisBranch>.*<\/latestReleasedVersionFromThisBranch>/<latestReleasedVersionFromThisBranch>$newVersion<\/latestReleasedVersionFromThisBranch>/" pom.xml
-            fi
-            # update version also for user BOMs, since they do not use the top level kie-parent
-            cd kie-user-bom-parent
-            mvnVersionsSet
-            cd ..
-            # the child poms (all boms/pom.xml) have to be updated
-            mvnVersionsUpdateChildModules
-            # update version that are not automatically updated
-            sed -i "s/<version.org.kie>$kieOldVersion<\/version.org.kie>/<version.org.kie>$newVersion<\/version.org.kie>/" pom.xml
-            # workaround for http://jira.codehaus.org/browse/MVERSIONS-161
-            mvn -B -s $settingsXmlFile clean install -DskipTests
-            returnCode=$?
-
-        elif [ "$repository" == "kie-soup" ]; then
-            mvnVersionsUpdateParentAndChildModules
-            returnCode=$?
-
-        elif [ "$repository" == "appformer" ]; then
-            # extract old kie version
-            kieOldVersion=$(grep -oP -m 1 '(?<=<version>).*(?=</version)' pom.xml)
-            mvnVersionsSet
-            # update version that are not automatically updated
-            sed -i "s/<version>$kieOldVersion<\/version>/<version>$newVersion<\/version>/" pom.xml
-            returnCode=$?
-
-        elif [ "$repository" == "jbpm" ]; then
-            mvnVersionsUpdateParentAndChildModules
-            returnCode=$?
-            sed -i "s/release.version=.*$/release.version=$newVersion/" jbpm-installer/src/main/resources/build.properties
-
-        elif [ "$repository" == "process-migration-service" ]; then
-            # extract old kie version
-            kieOldVersion=$(grep -oP -m 2 '(?<=<version>).*(?=</version)' pom.xml | sed -n 2p)
-          # update version since no mvn command works
-            sed -i "s/<version>$kieOldVersion<\/version>/<version>$newVersion<\/version>/" pom.xml
-            returnCode=$?
-
-        else
-            mvnVersionsUpdateParentAndChildModules
-            returnCode=$?
-        fi
-
-        if [ $returnCode != 0 ] ; then
-            exit $returnCode
-        fi
-
-        cd ..
+elif [ "$repository" == "droolsjbpm-build-bootstrap" ]; then
+    # first build&install the current version (usually SNAPSHOT) as it is needed later by other repos
+    mvn -B -U -Dfull clean install
+    # extract old kie version
+    kieOldVersion=$(grep -oP -m 2 '(?<=<version>).*(?=</version)' pom.xml| awk 'FNR==2')
+    mvnVersionsSet
+    # update latest released version property only for non-SNAPSHOT versions
+    if [[ ! $newVersion == *-SNAPSHOT ]]; then
+        sed -i "s/<latestReleasedVersionFromThisBranch>.*<\/latestReleasedVersionFromThisBranch>/<latestReleasedVersionFromThisBranch>$newVersion<\/latestReleasedVersionFromThisBranch>/" pom.xml
     fi
-done
+    # update version also for user BOMs, since they do not use the top level kie-parent
+    cd kie-user-bom-parent
+    mvnVersionsSet
+    cd ..
+    # the child poms (all boms/pom.xml) have to be updated
+    mvnVersionsUpdateChildModules
+    # update version that are not automatically updated
+    sed -i "s/<version.org.kie>$kieOldVersion<\/version.org.kie>/<version.org.kie>$newVersion<\/version.org.kie>/" pom.xml
+    # workaround for http://jira.codehaus.org/browse/MVERSIONS-161
+    mvn -B clean install -DskipTests
+    returnCode=$?
 
-endDateTime=`date +%s`
-spentSeconds=`expr $endDateTime - $startDateTime`
+elif [ "$repository" == "kie-soup" ]; then
+    mvnVersionsUpdateParentAndChildModules
+    returnCode=$?
 
-echo
-echo "Total time: ${spentSeconds}s"
+elif [ "$repository" == "appformer" ]; then
+    # extract old kie version
+    kieOldVersion=$(grep -oP -m 1 '(?<=<version>).*(?=</version)' pom.xml)
+    mvnVersionsSet
+    # update version that are not automatically updated
+    sed -i "s/<version>$kieOldVersion<\/version>/<version>$newVersion<\/version>/" pom.xml
+    returnCode=$?
+
+elif [ "$repository" == "jbpm" ]; then
+    mvnVersionsUpdateParentAndChildModules
+    returnCode=$?
+    sed -i "s/release.version=.*$/release.version=$newVersion/" jbpm-installer/src/main/resources/build.properties
+
+elif [ "$repository" == "process-migration-service" ]; then
+    # extract old kie version
+    kieOldVersion=$(grep -oP -m 2 '(?<=<version>).*(?=</version)' pom.xml | sed -n 2p)
+    # update version since no mvn command works
+    sed -i "s/<version>$kieOldVersion<\/version>/<version>$newVersion<\/version>/" pom.xml
+    returnCode=$?
+
+else
+    mvnVersionsUpdateParentAndChildModules
+    returnCode=$?
+fi
+
+if [ $returnCode != 0 ] ; then
+    exit $returnCode
+fi


### PR DESCRIPTION
this PR refactors the update script for build-chain, so the repository-lists are not needed anymore. This was tested locally and it worked. Please look at the changes. Your comments are welcome.

**Thank you for submitting this pull request**

**JIRA**: _(please edit the JIRA link if it exists)_ 

[BXMSPROD-2080](https://issues.redhat.com/browse/BXMSPROD-2080)

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* paste the link(s) from GitHub here
* link 2
* link 3 etc.

You can check Kiegroup organization repositories CI status from [Chain Status webpage](https://kiegroup.github.io/droolsjbpm-build-bootstrap/)

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used locally on command line or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it. 

A general local execution could be the following one, where the tool clones all dependent projects starting from the `-sp` one and it locally applies the pull request (if it exists) in order to reproduce a complete build scenario for the provided *Pull Request*.

> **Note:** the tool considers multiple *Pull Requests* related to each other if their branches (generally in the forked repositories) have the same name.

``` shell
$ build-chain-action -df 'https://raw.githubusercontent.com/${GROUP:kiegroup}/droolsjbpm-build-bootstrap/${BRANCH:main}/.ci/pull-request-config.yaml' build pr -url <pull-request-url> -sp kiegroup/kie-wb-distributions [--skipExecution]
```

> Consider changing `kiegroup/kie-wb-distributions` with the correct starting project.


</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest</b> (using <i>this</i> e.g. <b>Jenkins retest this</b> optional but no longer required)
 
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
    
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

* <b>for windows-specific os job</b> add the label `windows_check`
</details>

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>
