### PR TITLE
DROOLS-7533 `kie-jpmml-integration` 7.x depends on jbpmn main

### DIFF
--- a/.ci/project-dependencies.yaml
+++ b/.ci/project-dependencies.yaml
@@ -62,6 +62,17 @@ dependencies:
     dependencies:
       - project: kiegroup/drools
       - project: kiegroup/jbpm
+    mapping:
+      dependencies:
+        default:
+          - source: 7.x
+            target: main
+      dependant:
+        default:
+          - source: main
+            target: 7.x
+      exclude:
+        - kiegroup/drools
 
   - project: kiegroup/droolsjbpm-integration
     dependencies:


### PR DESCRIPTION
https://issues.redhat.com/browse/DROOLS-7533