### PR TITLE
Upgrade Kafka to address snappy-java vulnerabilities (CVE-2023-43642, CVE-2023-34455, ...)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -484,7 +484,7 @@
     <version.org.hisrc.jsonix.jsonix-scripts>3.0.0</version.org.hisrc.jsonix.jsonix-scripts>
     <version.org.jvnet.jaxb2.maven2.maven-jaxb2-plugin>0.15.3</version.org.jvnet.jaxb2.maven2.maven-jaxb2-plugin>
     <version.org.mock-server>5.11.1</version.org.mock-server>
-    <version.org.apache.kafka>3.1.0</version.org.apache.kafka>
+    <version.org.apache.kafka>3.6.0</version.org.apache.kafka>
     <version.shade.plugin>3.2.4</version.shade.plugin>
 
     <version.lock-treatment-tool>^0.2.2</version.lock-treatment-tool>

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
     <version.info.picocli>4.6.1</version.info.picocli>
     <version.io.micrometer>1.7.3</version.io.micrometer>
     <version.io.smallrye.openapi.core>2.1.4</version.io.smallrye.openapi.core>
-    <version.io.strimzi.strimzi-test-container>0.101.0</version.io.strimzi.strimzi-test-container>
+    <version.io.strimzi.strimzi-test-container>0.106.0</version.io.strimzi.strimzi-test-container>
     <version.io.takari.maven.plugins.testing>2.9.2</version.io.takari.maven.plugins.testing>
     <version.io.undertow>2.2.28.Final</version.io.undertow>
     <version.jaxen>1.1.6</version.jaxen>
@@ -484,7 +484,7 @@
     <version.org.hisrc.jsonix.jsonix-scripts>3.0.0</version.org.hisrc.jsonix.jsonix-scripts>
     <version.org.jvnet.jaxb2.maven2.maven-jaxb2-plugin>0.15.3</version.org.jvnet.jaxb2.maven2.maven-jaxb2-plugin>
     <version.org.mock-server>5.11.1</version.org.mock-server>
-    <version.org.apache.kafka>3.6.0</version.org.apache.kafka>
+    <version.org.apache.kafka>3.6.1</version.org.apache.kafka>
     <version.shade.plugin>3.2.4</version.shade.plugin>
 
     <version.lock-treatment-tool>^0.2.2</version.lock-treatment-tool>


### PR DESCRIPTION
This upgrade to Kafka 3.6.0 will result in an update of the snappy-java dependency to 1.1.10.4 to address the following vulnerabilities:

https://nvd.nist.gov/vuln/detail/CVE-2023-34453
https://nvd.nist.gov/vuln/detail/CVE-2023-34454
https://nvd.nist.gov/vuln/detail/CVE-2023-34455
https://nvd.nist.gov/vuln/detail/CVE-2023-43642