### PR TITLE
[7.67.x blue] Spring/SpringBoot upgrade to address CVEs in transitive dependencies

### DIFF
--- a/narayana-integration-bom/pom.xml
+++ b/narayana-integration-bom/pom.xml
@@ -24,7 +24,7 @@
     <!-- narayana dependencies for tomcat and kie server -->
     <version.org.jboss.narayana.tomcat>5.9.0.Final</version.org.jboss.narayana.tomcat>
     <!-- DBCP connection pooling for Narayana -->
-    <version.org.apache.tomcat.tomcat-dbcp>9.0.83</version.org.apache.tomcat.tomcat-dbcp>
+    <version.org.apache.tomcat.tomcat-dbcp>9.0.86</version.org.apache.tomcat.tomcat-dbcp>
 
     <version.org.jboss.transaction.spi>7.6.1.Final</version.org.jboss.transaction.spi>
     <version.jakarta.transaction-api>1.3.3</version.jakarta.transaction-api>

--- a/pom.xml
+++ b/pom.xml
@@ -377,7 +377,7 @@
     <!-- Make OSGi happy -->
     <osgi.snapshot.qualifier>${maven.build.timestamp}</osgi.snapshot.qualifier>
 
-    <version.io.netty>4.1.108.Final</version.io.netty>
+    <version.io.netty>4.1.77.Final</version.io.netty>
     <!-- IMPORTANT: Don't use this dependency. The right dependency version is the one named as "version.io.netty".
          This is just needed by Elasticsearch Transport Plugin because it has a compatibility mode with netty 3 and
          it can't be removed -->

--- a/pom.xml
+++ b/pom.xml
@@ -265,6 +265,7 @@
     <version.org.springframework>5.3.34</version.org.springframework>
     <version.org.springframework.boot>2.7.18</version.org.springframework.boot>
     <version.org.springframework.osgi>1.2.1</version.org.springframework.osgi>
+    <!-- spring-security.version and tomcat.version overrides version from spring-boot-dependencies bom -->
     <spring-security.version>5.7.12</spring-security.version>
     <tomcat.version>9.0.86</tomcat.version>
     <version.org.subethamail>1.2</version.org.subethamail>

--- a/pom.xml
+++ b/pom.xml
@@ -263,9 +263,9 @@
     <version.org.sonatype.sisu>2.3.0</version.org.sonatype.sisu>
     <version.org.sonatype.sisu.sisu-guice>3.2.3</version.org.sonatype.sisu.sisu-guice>
     <version.org.springframework>5.3.34</version.org.springframework>
-    <version.org.springframework.boot>2.5.15</version.org.springframework.boot>
+    <version.org.springframework.boot>2.7.18</version.org.springframework.boot>
     <version.org.springframework.osgi>1.2.1</version.org.springframework.osgi>
-    <version.spring.security>5.7.12</version.spring.security>
+    <spring-security.version>5.7.12</spring-security.version>
     <version.org.subethamail>1.2</version.org.subethamail>
     <version.org.subethamail.subethasmtp>3.1.6</version.org.subethamail.subethasmtp>
     <version.org.testcontainers>1.15.2</version.org.testcontainers>
@@ -4053,18 +4053,6 @@
         </exclusions>
       </dependency>
 
-     <dependency>
-        <groupId>org.apache.tomcat.embed</groupId>
-        <artifactId>tomcat-embed-core</artifactId>
-        <version>${version.org.apache.tomcat}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.tomcat.embed</groupId>
-        <artifactId>tomcat-embed-websocket</artifactId>
-        <version>${version.org.apache.tomcat}</version>
-      </dependency>
-
-
       <dependency>
         <groupId>org.apache.ws.xmlschema</groupId>
         <artifactId>xmlschema-core</artifactId>
@@ -5375,11 +5363,6 @@
         <version>${version.org.springframework.boot}</version>
       </dependency>
 
-      <dependency>
-        <groupId>org.springframework.security</groupId>
-        <artifactId>spring-security-core</artifactId>
-        <version>${version.spring.security}</version>
-      </dependency>
       <dependency>
         <groupId>org.subethamail</groupId>
         <artifactId>subethasmtp-wiser</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -266,6 +266,7 @@
     <version.org.springframework.boot>2.7.18</version.org.springframework.boot>
     <version.org.springframework.osgi>1.2.1</version.org.springframework.osgi>
     <spring-security.version>5.7.12</spring-security.version>
+    <tomcat.version>9.0.86</tomcat.version>
     <version.org.subethamail>1.2</version.org.subethamail>
     <version.org.subethamail.subethasmtp>3.1.6</version.org.subethamail.subethasmtp>
     <version.org.testcontainers>1.15.2</version.org.testcontainers>
@@ -5324,7 +5325,6 @@
         <groupId>org.springframework</groupId>
         <artifactId>spring-web</artifactId>
         <version>${version.org.springframework}</version>
-        <!-- <version>5.3.34</version> -->
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -377,7 +377,7 @@
     <!-- Make OSGi happy -->
     <osgi.snapshot.qualifier>${maven.build.timestamp}</osgi.snapshot.qualifier>
 
-    <version.io.netty>4.1.77.Final</version.io.netty>
+    <version.io.netty>4.1.108.Final</version.io.netty>
     <!-- IMPORTANT: Don't use this dependency. The right dependency version is the one named as "version.io.netty".
          This is just needed by Elasticsearch Transport Plugin because it has a compatibility mode with netty 3 and
          it can't be removed -->

--- a/pom.xml
+++ b/pom.xml
@@ -4053,6 +4053,18 @@
       </dependency>
 
       <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-core</artifactId>
+        <version>9.0.86</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-websocket</artifactId>
+        <version>9.0.86</version>
+      </dependency>
+
+
+      <dependency>
         <groupId>org.apache.ws.xmlschema</groupId>
         <artifactId>xmlschema-core</artifactId>
         <version>${version.org.apache.ws.xmlschema}</version>
@@ -5322,7 +5334,8 @@
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-web</artifactId>
-        <version>${version.org.springframework}</version>
+        <!-- <version>${version.org.springframework}</version> -->
+        <version>5.3.34</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
@@ -5360,6 +5373,13 @@
         <artifactId>spring-boot-test-autoconfigure</artifactId>
         <version>${version.org.springframework.boot}</version>
       </dependency>
+
+      <dependency>
+        <groupId>org.springframework.security</groupId>
+        <artifactId>spring-security-core</artifactId>
+        <version>5.7.12</version>
+      </dependency>
+
 
       <dependency>
         <groupId>org.subethamail</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -153,7 +153,7 @@
     <version.org.apache.neethi>3.1.1</version.org.apache.neethi>
     <version.org.apache.poi>4.1.2</version.org.apache.poi>
     <version.org.apache.sshd>2.9.2</version.org.apache.sshd>
-    <version.org.apache.tomcat>9.0.83</version.org.apache.tomcat>
+    <version.org.apache.tomcat>9.0.86</version.org.apache.tomcat>
     <version.org.apache.velocity>1.7</version.org.apache.velocity>
     <version.org.apache.xmlbeans>3.1.0</version.org.apache.xmlbeans>
     <version.org.apache.ws.xmlschema>2.2.5</version.org.apache.ws.xmlschema>
@@ -262,9 +262,10 @@
     <version.org.sonatype.plexus.plexus-sec-dispatcher>2.0</version.org.sonatype.plexus.plexus-sec-dispatcher>
     <version.org.sonatype.sisu>2.3.0</version.org.sonatype.sisu>
     <version.org.sonatype.sisu.sisu-guice>3.2.3</version.org.sonatype.sisu.sisu-guice>
-    <version.org.springframework>5.3.27</version.org.springframework>
+    <version.org.springframework>5.3.34</version.org.springframework>
     <version.org.springframework.boot>2.5.15</version.org.springframework.boot>
     <version.org.springframework.osgi>1.2.1</version.org.springframework.osgi>
+    <version.spring.security>5.7.12</version.spring.security>
     <version.org.subethamail>1.2</version.org.subethamail>
     <version.org.subethamail.subethasmtp>3.1.6</version.org.subethamail.subethasmtp>
     <version.org.testcontainers>1.15.2</version.org.testcontainers>
@@ -4052,15 +4053,15 @@
         </exclusions>
       </dependency>
 
-      <dependency>
+     <dependency>
         <groupId>org.apache.tomcat.embed</groupId>
         <artifactId>tomcat-embed-core</artifactId>
-        <version>9.0.86</version>
+        <version>${version.org.apache.tomcat}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.tomcat.embed</groupId>
         <artifactId>tomcat-embed-websocket</artifactId>
-        <version>9.0.86</version>
+        <version>${version.org.apache.tomcat}</version>
       </dependency>
 
 
@@ -5334,8 +5335,8 @@
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-web</artifactId>
-        <!-- <version>${version.org.springframework}</version> -->
-        <version>5.3.34</version>
+        <version>${version.org.springframework}</version>
+        <!-- <version>5.3.34</version> -->
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
@@ -5377,10 +5378,8 @@
       <dependency>
         <groupId>org.springframework.security</groupId>
         <artifactId>spring-security-core</artifactId>
-        <version>5.7.12</version>
+        <version>${version.spring.security}</version>
       </dependency>
-
-
       <dependency>
         <groupId>org.subethamail</groupId>
         <artifactId>subethasmtp-wiser</artifactId>


### PR DESCRIPTION
**referenced Pull Requests**: https://github.com/kiegroup/droolsjbpm-integration/pull/3055

You can check Kiegroup organization repositories CI status from [Chain Status webpage](https://kiegroup.github.io/droolsjbpm-build-bootstrap/)

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used locally on command line or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it. 

A general local execution could be the following one, where the tool clones all dependent projects starting from the `-sp` one and it locally applies the pull request (if it exists) in order to reproduce a complete build scenario for the provided *Pull Request*.

> **Note:** the tool considers multiple *Pull Requests* related to each other if their branches (generally in the forked repositories) have the same name.

``` shell
$ build-chain-action -df 'https://raw.githubusercontent.com/${GROUP:kiegroup}/droolsjbpm-build-bootstrap/${BRANCH:main}/.ci/pull-request-config.yaml' build pr -url <pull-request-url> -sp kiegroup/kie-wb-distributions [--skipExecution]
```

> Consider changing `kiegroup/kie-wb-distributions` with the correct starting project.


</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest</b> (using <i>this</i> e.g. <b>Jenkins retest this</b> optional but no longer required)
 
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
    
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

* <b>for windows-specific os job</b> add the label `windows_check`
</details>

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>
