### PR TITLE
[7.67.x-blue] Update mysql connector

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
     <version.joda-time>2.9.7</version.joda-time>
     <version.junit>4.13.1</version.junit>
     <version.enforcer.plugin>3.0.0-M3</version.enforcer.plugin>
-    <version.mysql.connector-java>8.0.28</version.mysql.connector-java>
+    <version.mysql.connector-java>8.2.0</version.mysql.connector-java>
     <version.net.jcip>1.0</version.net.jcip>
     <version.net.java.dev.glazedlists>1.8.0</version.net.java.dev.glazedlists>
     <version.net.sf.opencsv>2.3</version.net.sf.opencsv>

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
     <version.joda-time>2.9.7</version.joda-time>
     <version.junit>4.13.1</version.junit>
     <version.enforcer.plugin>3.0.0-M3</version.enforcer.plugin>
-    <version.mysql.connector-java>8.2.0</version.mysql.connector-java>
+    <version.mysql.connector-j>8.2.0</version.mysql.connector-j>
     <version.net.jcip>1.0</version.net.jcip>
     <version.net.java.dev.glazedlists>1.8.0</version.net.java.dev.glazedlists>
     <version.net.sf.opencsv>2.3</version.net.sf.opencsv>
@@ -6362,9 +6362,9 @@
       </dependency>
 
       <dependency>
-        <groupId>mysql</groupId>
-        <artifactId>mysql-connector-java</artifactId>
-        <version>${version.mysql.connector-java}</version>
+        <groupId>com.mysql</groupId>
+        <artifactId>mysql-connector-j</artifactId>
+        <version>${version.mysql.connector-j}</version>
         <scope>runtime</scope>
       </dependency>
 


### PR DESCRIPTION
The mysql-connector needs to be updated to avoid CVE-2023-22102. The GAV completely changed going from mysql:mysql-connector-java:8.0.28 to com.mysql:mysql-connector-j:8.2.0.

Related PR: https://github.com/kiegroup/appformer/pull/1417