### PR TITLE
[7.67.x-blue] Upgrading Apache Velocity to 2.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@
     <version.org.apache.poi>4.1.2</version.org.apache.poi>
     <version.org.apache.sshd>2.9.2</version.org.apache.sshd>
     <version.org.apache.tomcat>9.0.83</version.org.apache.tomcat>
-    <version.org.apache.velocity>1.7</version.org.apache.velocity>
+    <version.org.apache.velocity>2.3</version.org.apache.velocity>
     <version.org.apache.xmlbeans>3.1.0</version.org.apache.xmlbeans>
     <version.org.apache.ws.xmlschema>2.2.5</version.org.apache.ws.xmlschema>
     <version.org.apache.xmlgraphics.batik>1.17</version.org.apache.xmlgraphics.batik>
@@ -4060,7 +4060,7 @@
 
       <dependency>
         <groupId>org.apache.velocity</groupId>
-        <artifactId>velocity</artifactId>
+        <artifactId>velocity-engine-core</artifactId>
         <version>${version.org.apache.velocity}</version>
       </dependency>
 


### PR DESCRIPTION
Full GAV change:
org.apache.velocity:velocity:1.7 ->
org.apache.velocity:velocity-engine-core:2.3

Referenced PRs:

- #2473
- https://github.com/kiegroup/kie-wb-common/pull/3829- 

NOTE: There are some changes that need to be made to the velocity configuration. These can be found at https://velocity.apache.org/engine/2.3/upgrading.html#upgrading-from-velocity-22-to-velocity-23. Read all changes until 1.7 to 2.0.
They all apply to this upgrade.
Test and verify any usage of Apache Velocity templates.