### PR TITLE
Trying strimzi test container 0.103.0 to fix jdk8 build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
     <version.info.picocli>4.6.1</version.info.picocli>
     <version.io.micrometer>1.7.3</version.io.micrometer>
     <version.io.smallrye.openapi.core>2.1.4</version.io.smallrye.openapi.core>
-    <version.io.strimzi.strimzi-test-container>0.106.0</version.io.strimzi.strimzi-test-container>
+    <version.io.strimzi.strimzi-test-container>0.103.0</version.io.strimzi.strimzi-test-container>
     <version.io.takari.maven.plugins.testing>2.9.2</version.io.takari.maven.plugins.testing>
     <version.io.undertow>2.2.33.Final</version.io.undertow>
     <version.jaxen>1.1.6</version.jaxen>


### PR DESCRIPTION
JDK 8 nighlies are now failing due strimzi-test-container is compiled to java 11 and this breaks our JDK8 nighly.

```
[2024-10-13T23:10:07.047Z] [INFO] Repository WildFly ................................. SUCCESS [ 10.206 s]
[2024-10-13T23:10:07.048Z] [INFO] karaf-itests ....................................... SUCCESS [  3.441 s]
[2024-10-13T23:10:07.048Z] [INFO] jBPM :: WorkItem :: SpringBoot :: IntegrationTests . FAILURE [  5.214 s]
[2024-10-13T23:10:07.048Z] [INFO] ------------------------------------------------------------------------
[2024-10-13T23:10:07.048Z] [INFO] BUILD FAILURE
[2024-10-13T23:10:07.048Z] [INFO] ------------------------------------------------------------------------
[2024-10-13T23:10:07.048Z] [INFO] Total time:  06:07 min
[2024-10-13T23:10:07.048Z] [INFO] Finished at: 2024-10-13T19:10:05-04:00
[2024-10-13T23:10:07.048Z] [INFO] ------------------------------------------------------------------------
[2024-10-13T23:10:07.048Z] [WARNING] The requested profile "run-code-coverage" could not be activated because it does not exist.
[2024-10-13T23:10:07.048Z] [ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.1:testCompile (default-testCompile) on project jbpm-workitem-itests: Compilation failure
[2024-10-13T23:10:07.048Z] [ERROR] /home/jenkins/workspace/KIE/main/daily-build-jdk8/jdk8-db-main/bc/kiegroup_jbpm-work-items/jbpm-workitem-itests/src/test/java/org/jbpm/workitem/springboot/samples/KafkaFixture.java:[42,33] cannot access io.strimzi.test.container.StrimziKafkaContainer
[2024-10-13T23:10:07.048Z] [ERROR]   bad class file: /home/jenkins/.m2/repository/io/strimzi/strimzi-test-container/0.106.0/strimzi-test-container-0.106.0.jar(io/strimzi/test/container/StrimziKafkaContainer.class)
[2024-10-13T23:10:07.048Z] [ERROR]     class file has wrong version 55.0, should be 52.0
[2024-10-13T23:10:07.048Z] [ERROR]     Please remove or make sure it appears in the correct subdirectory of the classpath.
[2024-10-13T23:10:07.048Z] [ERROR] -> [Help 1]
[2024-10-13T23:10:07.048Z] org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.1:testCompile (default-testCompile) on project jbpm-workitem-itests: Compilation failure
[2024-10-13T23:10:07.048Z] /home/jenkins/workspace/KIE/main/daily-build-jdk8/jdk8-db-main/bc/kiegroup_jbpm-work-items/jbpm-workitem-itests/src/test/java/org/jbpm/workitem/springboot/samples/KafkaFixture.java:[42,33] cannot access io.strimzi.test.container.StrimziKafkaContainer
[2024-10-13T23:10:07.048Z]   bad class file: /home/jenkins/.m2/repository/io/strimzi/strimzi-test-container/0.106.0/strimzi-test-container-0.106.0.jar(io/strimzi/test/container/StrimziKafkaContainer.class)
[2024-10-13T23:10:07.048Z]     class file has wrong version 55.0, should be 52.0
[2024-10-13T23:10:07.048Z]     Please remove or make sure it appears in the correct subdirectory of the classpath.
[2024-10-13T23:10:07.048Z] 
[2024-10-13T23:10:07.048Z]     at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:215)
[2024-10-13T23:10:07.048Z]     at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:156)
[2024-10-13T23:10:07.048Z]     at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:148)
[2024-10-13T23:10:07.048Z]     at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
[2024-10-13T23:10:07.048Z]     at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
[2024-10-13T23:10:07.048Z]     at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
[2024-10-13T23:10:07.048Z]     at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
[2024-10-13T23:10:07.048Z]     at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:305)
[2024-10-13T23:10:07.048Z]     at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
[2024-10-13T23:10:07.048Z]     at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
[2024-10-13T23:10:07.048Z]     at org.apache.maven.cli.MavenCli.execute (MavenCli.java:957)
[2024-10-13T23:10:07.048Z]     at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:289)
[2024-10-13T23:10:07.048Z]     at org.apache.maven.cli.MavenCli.main (MavenCli.java:193)
[2024-10-13T23:10:07.048Z]     at sun.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
[2024-10-13T23:10:07.048Z]     at sun.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
[2024-10-13T23:10:07.048Z]     at sun.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
[2024-10-13T23:10:07.048Z]     at java.lang.reflect.Method.invoke (Method.java:498)
[2024-10-13T23:10:07.048Z]     at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
[2024-10-13T23:10:07.048Z]     at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
[2024-10-13T23:10:07.048Z]     at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
[2024-10-13T23:10:07.048Z]     at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
[2024-10-13T23:10:07.048Z] Caused by: org.apache.maven.plugin.compiler.CompilationFailureException: Compilation failure
[2024-10-13T23:10:07.048Z] /home/jenkins/workspace/KIE/main/daily-build-jdk8/jdk8-db-main/bc/kiegroup_jbpm-work-items/jbpm-workitem-itests/src/test/java/org/jbpm/workitem/springboot/samples/KafkaFixture.java:[42,33] cannot access io.strimzi.test.container.StrimziKafkaContainer
[2024-10-13T23:10:07.048Z]   bad class file: /home/jenkins/.m2/repository/io/strimzi/strimzi-test-container/0.106.0/strimzi-test-container-0.106.0.jar(io/strimzi/test/container/StrimziKafkaContainer.class)
[2024-10-13T23:10:07.048Z]     class file has wrong version 55.0, should be 52.0
[2024-10-13T23:10:07.048Z]     Please remove or make sure it appears in the correct subdirectory of the classpath.
[2024-10-13T23:10:07.048Z] 
[2024-10-13T23:10:07.048Z]     at org.apache.maven.plugin.compiler.AbstractCompilerMojo.execute (AbstractCompilerMojo.java:1220)
[2024-10-13T23:10:07.048Z]     at org.apache.maven.plugin.compiler.TestCompilerMojo.execute (TestCompilerMojo.java:180)
[2024-10-13T23:10:07.048Z]     at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:137)
[2024-10-13T23:10:07.048Z]     at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:210)
[2024-10-13T23:10:07.048Z]     at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:156)
[2024-10-13T23:10:07.048Z]     at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:148)
[2024-10-13T23:10:07.048Z]     at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
[2024-10-13T23:10:07.048Z]     at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
[2024-10-13T23:10:07.048Z]     at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
[2024-10-13T23:10:07.048Z]     at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
[2024-10-13T23:10:07.048Z]     at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:305)
[2024-10-13T23:10:07.048Z]     at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
[2024-10-13T23:10:07.048Z]     at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
[2024-10-13T23:10:07.048Z]     at org.apache.maven.cli.MavenCli.execute (MavenCli.java:957)
[2024-10-13T23:10:07.048Z]     at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:289)
[2024-10-13T23:10:07.048Z]     at org.apache.maven.cli.MavenCli.main (MavenCli.java:193)
[2024-10-13T23:10:07.048Z]     at sun.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
[2024-10-13T23:10:07.048Z]     at sun.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
[2024-10-13T23:10:07.048Z]     at sun.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
[2024-10-13T23:10:07.048Z]     at java.lang.reflect.Method.invoke (Method.java:498)
[2024-10-13T23:10:07.048Z]     at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
[2024-10-13T23:10:07.048Z]     at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
[2024-10-13T23:10:07.048Z]     at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
[2024-10-13T23:10:07.048Z]     at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
[2024-10-13T23:10:07.048Z] [ERROR] 
[2024-10-13T23:10:07.048Z] [ERROR] Re-run Maven using the -X switch to enable full debug logging.
[2024-10-13T23:10:07.048Z] [ERROR] 
[2024-10-13T23:10:07.048Z] [ERROR] For more information about the errors and possible solutions, please read the following articles:
[2024-10-13T23:10:07.048Z] [ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
[2024-10-13T23:10:07.048Z] [ERROR] 
[2024-10-13T23:10:07.048Z] [ERROR] After correcting the problems, you can resume the build with the command
[2024-10-13T23:10:07.048Z] [ERROR]   mvn <args> -rf :jbpm-workitem-itests
```

[link](https://www.example.com)

**referenced Pull Requests**:

* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/2445

You can check Kiegroup organization repositories CI status from [Chain Status webpage](https://kiegroup.github.io/droolsjbpm-build-bootstrap/)

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used locally on command line or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it. 

A general local execution could be the following one, where the tool clones all dependent projects starting from the `-sp` one and it locally applies the pull request (if it exists) in order to reproduce a complete build scenario for the provided *Pull Request*.

> **Note:** the tool considers multiple *Pull Requests* related to each other if their branches (generally in the forked repositories) have the same name.

``` shell
$ build-chain-action -df 'https://raw.githubusercontent.com/${GROUP:kiegroup}/droolsjbpm-build-bootstrap/${BRANCH:main}/.ci/pull-request-config.yaml' build pr -url <pull-request-url> -sp kiegroup/kie-wb-distributions [--skipExecution]
```

> Consider changing `kiegroup/kie-wb-distributions` with the correct starting project.


</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest</b> (using <i>this</i> e.g. <b>Jenkins retest this</b> optional but no longer required)
 
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
    
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

* <b>for windows-specific os job</b> add the label `windows_check`
</details>

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>
