### PR TITLE
[7.67.x-blue] NO-ISSUE: Bump `xstream` to version `1.4.21`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -333,8 +333,8 @@
     <version.org.ow2.asm>9.2</version.org.ow2.asm>
     <version.org.wildfly.security>1.15.16.Final</version.org.wildfly.security>
     <version.org.picketlink>2.7.1.Final</version.org.picketlink>
-    <version.org.revapi>0.15.0</version.org.revapi>
-    <version.org.revapi.java>0.28.1</version.org.revapi.java>
+    <version.org.revapi>0.9.5</version.org.revapi>
+    <version.org.revapi.java>0.14.3</version.org.revapi.java>
     <version.com.unboundid>4.0.5</version.com.unboundid>
     <version.com.wordnik.swagger>1.3.10</version.com.wordnik.swagger>
     <version.io.swagger>1.6.2</version.io.swagger>

--- a/pom.xml
+++ b/pom.xml
@@ -448,7 +448,7 @@
     </jboss.snapshots.repo.url>
 
     <!-- Latest release to be used by api-compatibility-check to check backwards compatibility of the Kie API. -->
-    <revapi.oldKieVersion>7.67.0.Final</revapi.oldKieVersion>
+    <revapi.oldKieVersion>7.59.0.Final</revapi.oldKieVersion>
     <revapi.newKieVersion>${project.version}</revapi.newKieVersion>
 
     <version.org.apache.maven.plugins.dependency>3.0.2</version.org.apache.maven.plugins.dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
     <version.com.neovisionaries>1.27</version.com.neovisionaries>
     <version.com.networknt.json-schema-validator>1.0.43</version.com.networknt.json-schema-validator>
     <version.com.sun.xml.bind>2.3.0</version.com.sun.xml.bind>
-    <version.com.thoughtworks.xstream>1.4.20</version.com.thoughtworks.xstream>
+    <version.com.thoughtworks.xstream>1.4.21</version.com.thoughtworks.xstream>
     <version.de.benediktmeurer.gwt-slf4j>0.0.2</version.de.benediktmeurer.gwt-slf4j>
     <version.org.dom4j>2.1.3</version.org.dom4j>
     <version.guru.nidi>0.18.0</version.guru.nidi>

--- a/pom.xml
+++ b/pom.xml
@@ -448,7 +448,7 @@
     </jboss.snapshots.repo.url>
 
     <!-- Latest release to be used by api-compatibility-check to check backwards compatibility of the Kie API. -->
-    <revapi.oldKieVersion>7.59.0.Final</revapi.oldKieVersion>
+    <revapi.oldKieVersion>7.67.0.Final</revapi.oldKieVersion>
     <revapi.newKieVersion>${project.version}</revapi.newKieVersion>
 
     <version.org.apache.maven.plugins.dependency>3.0.2</version.org.apache.maven.plugins.dependency>
@@ -1072,12 +1072,12 @@
         <plugin>
           <groupId>org.revapi</groupId>
           <artifactId>revapi-maven-plugin</artifactId>
-          <version>0.9.5</version>
+          <version>${version.org.revapi}</version>
           <dependencies>
             <dependency>
               <groupId>org.revapi</groupId>
               <artifactId>revapi-java</artifactId>
-              <version>0.14.3</version>
+              <version>${version.org.revapi.java}</version>
             </dependency>
           </dependencies>
           <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -333,6 +333,8 @@
     <version.org.ow2.asm>9.2</version.org.ow2.asm>
     <version.org.wildfly.security>1.15.16.Final</version.org.wildfly.security>
     <version.org.picketlink>2.6.0.Final</version.org.picketlink>
+    <version.org.revapi>0.15.0</version.org.revapi>
+    <version.org.revapi.java>0.28.1</version.org.revapi.java>
     <version.com.unboundid>4.0.5</version.com.unboundid>
     <version.com.wordnik.swagger>1.3.10</version.com.wordnik.swagger>
     <version.io.swagger>1.6.2</version.io.swagger>


### PR DESCRIPTION
The current `xstream` `1.4.20` is affected by [CVE-2024-47072](https://x-stream.github.io/CVE-2024-47072.html).
Updating `xstream` to ´1.4.21´ resolves the CVE

Related PR: https://github.com/kiegroup/droolsjbpm-integration/pull/3068