### PR TITLE
[7.67.x-blue] update picketlink libraries version to 2.7.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -332,7 +332,7 @@
     <!-- Required by jboss-remoting version above -->
     <version.org.ow2.asm>9.2</version.org.ow2.asm>
     <version.org.wildfly.security>1.15.16.Final</version.org.wildfly.security>
-    <version.org.picketlink>2.6.0.Final</version.org.picketlink>
+    <version.org.picketlink>2.7.0.Final</version.org.picketlink>
     <version.com.unboundid>4.0.5</version.com.unboundid>
     <version.com.wordnik.swagger>1.3.10</version.com.wordnik.swagger>
     <version.io.swagger>1.6.2</version.io.swagger>

--- a/pom.xml
+++ b/pom.xml
@@ -332,7 +332,7 @@
     <!-- Required by jboss-remoting version above -->
     <version.org.ow2.asm>9.2</version.org.ow2.asm>
     <version.org.wildfly.security>1.15.16.Final</version.org.wildfly.security>
-    <version.org.picketlink>2.7.0.Final</version.org.picketlink>
+    <version.org.picketlink>2.7.1.Final</version.org.picketlink>
     <version.com.unboundid>4.0.5</version.com.unboundid>
     <version.com.wordnik.swagger>1.3.10</version.com.wordnik.swagger>
     <version.io.swagger>1.6.2</version.io.swagger>


### PR DESCRIPTION
The current picketlink '2.6.0' version is  is affected by [CVE-2015-0277] [CVE-2015-6254]
Updating picketlink to '2.7.1' resolves the CVE

