### PR TITLE
[kie-issues#1788] Updating keycloak to 26.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -244,7 +244,7 @@
     <version.org.json>20231013</version.org.json>
     <version.org.jsoup>1.15.3</version.org.jsoup>
     <version.org.junit>5.5.2</version.org.junit>
-    <version.org.keycloak>20.0.3</version.org.keycloak>
+    <version.org.keycloak>26.0.1</version.org.keycloak>
     <version.org.mvel>2.5.2.Final</version.org.mvel>
     <version.org.apache.logging.log4j>2.17.1</version.org.apache.logging.log4j>
     <version.org.ocpsoft.prettytime>3.0.2.Final</version.org.ocpsoft.prettytime>


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-kie-issues/issues/1788

I think this will cover everything if the whole build is run, but another set of eyes on the whole dependency graph would be useful.

This syncs the version of Keycloak with what Quarkus 3.15.3 is using