### PR TITLE
[7.67.x-blue] upgrade wildfly elytron library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -331,7 +331,7 @@
     <version.org.jboss.errai.wildfly>23.0.0.Final</version.org.jboss.errai.wildfly>
     <!-- Required by jboss-remoting version above -->
     <version.org.ow2.asm>9.2</version.org.ow2.asm>
-D    <version.org.wildfly.security>1.15.24.Final</version.org.wildfly.security>
+    <version.org.wildfly.security>1.15.24.Final</version.org.wildfly.security>
     <version.org.picketlink>2.7.1.Final</version.org.picketlink>
     <version.com.unboundid>4.0.5</version.com.unboundid>
     <version.com.wordnik.swagger>1.3.10</version.com.wordnik.swagger>

--- a/pom.xml
+++ b/pom.xml
@@ -192,7 +192,7 @@
     <version.org.hibernate.validator>6.0.20.Final</version.org.hibernate.validator>
     <version.org.hibernate.commons.annotations>5.0.5.Final</version.org.hibernate.commons.annotations>
     <version.org.hornetq>2.4.7.Final</version.org.hornetq>
-    <version.org.infinispan>14.0.28.Final</version.org.infinispan>
+    <version.org.infinispan>14.0.27.Final</version.org.infinispan>
     <!--This needs to be in sync with JUnit-->
     <version.org.hamcrest>1.3</version.org.hamcrest>
     <version.org.hsqldb>2.3.0</version.org.hsqldb>
@@ -331,7 +331,7 @@
     <version.org.jboss.errai.wildfly>23.0.0.Final</version.org.jboss.errai.wildfly>
     <!-- Required by jboss-remoting version above -->
     <version.org.ow2.asm>9.2</version.org.ow2.asm>
-    <version.org.wildfly.security>2.2.5.Final</version.org.wildfly.security>
+D    <version.org.wildfly.security>1.15.24.Final</version.org.wildfly.security>
     <version.org.picketlink>2.7.1.Final</version.org.picketlink>
     <version.com.unboundid>4.0.5</version.com.unboundid>
     <version.com.wordnik.swagger>1.3.10</version.com.wordnik.swagger>

--- a/pom.xml
+++ b/pom.xml
@@ -192,7 +192,7 @@
     <version.org.hibernate.validator>6.0.20.Final</version.org.hibernate.validator>
     <version.org.hibernate.commons.annotations>5.0.5.Final</version.org.hibernate.commons.annotations>
     <version.org.hornetq>2.4.7.Final</version.org.hornetq>
-    <version.org.infinispan>14.0.27.Final</version.org.infinispan>
+    <version.org.infinispan>14.0.28.Final</version.org.infinispan>
     <!--This needs to be in sync with JUnit-->
     <version.org.hamcrest>1.3</version.org.hamcrest>
     <version.org.hsqldb>2.3.0</version.org.hsqldb>
@@ -331,7 +331,7 @@
     <version.org.jboss.errai.wildfly>23.0.0.Final</version.org.jboss.errai.wildfly>
     <!-- Required by jboss-remoting version above -->
     <version.org.ow2.asm>9.2</version.org.ow2.asm>
-    <version.org.wildfly.security>1.15.16.Final</version.org.wildfly.security>
+    <version.org.wildfly.security>2.2.5.Final</version.org.wildfly.security>
     <version.org.picketlink>2.7.1.Final</version.org.picketlink>
     <version.com.unboundid>4.0.5</version.com.unboundid>
     <version.com.wordnik.swagger>1.3.10</version.com.wordnik.swagger>


### PR DESCRIPTION
The current version is affected by CVE-2023-6236. So upgrading to  2.2.5.Final version of wildfly-elytron and infinispan to 4.0.28.Final.