### PR TITLE
[CVE] Fix CVE-2021-20250 (jboss-remoting)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -205,7 +205,6 @@
     <version.org.jboss.resteasy>3.15.6.Final</version.org.jboss.resteasy>
     <version.org.jboss.marshalling>2.0.11.Final</version.org.jboss.marshalling>
     <version.org.jboss.forge.roaster>2.19.5.Final</version.org.jboss.forge.roaster>
-    <version.org.jboss.remote-naming>2.0.5.Final</version.org.jboss.remote-naming>
     <version.org.jboss.remoting>5.0.20.Final</version.org.jboss.remoting>
     <version.org.jboss.shrinkwrap.resolver>2.2.0</version.org.jboss.shrinkwrap.resolver>
     <version.org.jboss.weld.weld>3.1.6.Final</version.org.jboss.weld.weld>
@@ -4877,9 +4876,9 @@
 
 
       <dependency>
-        <groupId>org.jboss.remoting</groupId>
-        <artifactId>jboss-remoting</artifactId>
-        <version>${version.org.jboss.remoting}</version>
+        <groupId>org.wildfly.core</groupId>
+        <artifactId>wildfly-remoting</artifactId>
+        <version>${version.org.wildfly.core}</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -205,7 +205,8 @@
     <version.org.jboss.resteasy>3.15.6.Final</version.org.jboss.resteasy>
     <version.org.jboss.marshalling>2.0.11.Final</version.org.jboss.marshalling>
     <version.org.jboss.forge.roaster>2.19.5.Final</version.org.jboss.forge.roaster>
-    <version.org.jboss.remoting>5.0.20.Final</version.org.jboss.remoting>
+    <version.org.jboss.remote-naming>2.0.5.Final</version.org.jboss.remote-naming>
+    <version.org.jboss.remoting>5.0.30.Final</version.org.jboss.remoting>
     <version.org.jboss.shrinkwrap.resolver>2.2.0</version.org.jboss.shrinkwrap.resolver>
     <version.org.jboss.weld.weld>3.1.6.Final</version.org.jboss.weld.weld>
     <version.org.jboss.weld.weld-api>3.1.SP3</version.org.jboss.weld.weld-api>
@@ -4876,9 +4877,9 @@
 
 
       <dependency>
-        <groupId>org.wildfly.core</groupId>
-        <artifactId>wildfly-remoting</artifactId>
-        <version>${version.org.wildfly.core}</version>
+        <groupId>org.jboss.remoting</groupId>
+        <artifactId>jboss-remoting</artifactId>
+        <version>${version.org.jboss.remoting}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Issue in the remoting code that we're putting in from JBoss. EAP 7.4.20 is using wildfly, so aligning with that version.