### PR TITLE
[7.67.x-blue] Removes duplicate Tomcat version property that is not needed anymore

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -268,8 +268,6 @@
     <version.org.springframework>5.3.39</version.org.springframework>
     <version.org.springframework.boot>2.7.18</version.org.springframework.boot>
     <version.org.springframework.osgi>1.2.1</version.org.springframework.osgi>
-    <!-- spring-security.version and tomcat.version overrides version from spring-boot-dependencies bom -->
-    <tomcat.version>9.0.86</tomcat.version>
     <version.org.subethamail>1.2</version.org.subethamail>
     <version.org.subethamail.subethasmtp>3.1.6</version.org.subethamail.subethasmtp>
     <version.org.testcontainers>1.15.2</version.org.testcontainers>


### PR DESCRIPTION
The property was used to override some version in the past, however now only the property from here is used https://github.com/kiegroup/droolsjbpm-build-bootstrap/blob/7.67.x-blue/pom.xml#L157. 

Not needed to be merged for BAMOE 8.0.7. 