### PR TITLE
[7.67.x-blue] upgrade wildfly core version from 17.0.0.Final to 22.0.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -278,7 +278,7 @@
     <version.org.wildfly>23.0.0.Final</version.org.wildfly>
     <version.org.wildfly.arquillian>3.0.1.Final</version.org.wildfly.arquillian>
     <version.org.wildfly.client>1.0.1.Final</version.org.wildfly.client>
-    <version.org.wildfly.core>17.0.0.Final</version.org.wildfly.core>
+    <version.org.wildfly.core>22.0.0.Final</version.org.wildfly.core>
     <version.org.wildfly.common>1.5.4.Final</version.org.wildfly.common>
     <version.org.yaml.snakeyaml>2.0</version.org.yaml.snakeyaml>
     <version.org.mozilla.rhino>1.7.13</version.org.mozilla.rhino>


### PR DESCRIPTION
The current wildfly-controller version 17.0.0.Final is affected by [CVE-2023-4061]
Updating wildfly-controller and wildfly-cli to version 22.0.0.Final resolves the CVE