### PR TITLE
[7.67.x-blue] Upgrade netty handler version to 4.1.118.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -385,10 +385,6 @@
     <osgi.snapshot.qualifier>${maven.build.timestamp}</osgi.snapshot.qualifier>
 
     <version.io.netty>4.1.118.Final</version.io.netty>
-    <!-- IMPORTANT: Don't use this dependency. The right dependency version is the one named as "version.io.netty".
-         This is just needed by Elasticsearch Transport Plugin because it has a compatibility mode with netty 3 and
-         it can't be removed -->
-    <version.io.netty.old>3.10.6.Final</version.io.netty.old>
 
     <!-- Plugin version overrides.
          IMPORTANT: always explain the reason for overriding the plugin version! -->
@@ -2632,8 +2628,13 @@
 
       <dependency>
         <groupId>io.netty</groupId>
-        <artifactId>netty</artifactId>
-        <version>${version.io.netty.old}</version>
+        <artifactId>netty-all</artifactId>
+        <version>${version.io.netty}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-handler</artifactId>
+        <version>${version.io.netty}</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -384,7 +384,7 @@
     <!-- Make OSGi happy -->
     <osgi.snapshot.qualifier>${maven.build.timestamp}</osgi.snapshot.qualifier>
 
-    <version.io.netty>4.1.117.Final</version.io.netty>
+    <version.io.netty>4.1.118.Final</version.io.netty>
     <!-- IMPORTANT: Don't use this dependency. The right dependency version is the one named as "version.io.netty".
          This is just needed by Elasticsearch Transport Plugin because it has a compatibility mode with netty 3 and
          it can't be removed -->


### PR DESCRIPTION
Updating netty-handler to version `4.1.118.Final` resolves the [CVE-2025-24970]