### PR TITLE
[7.67.x-blue]CVE fix-Update logback-classic and logback-core from 1.2.13 to 1.5.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     -->
     <version.aopalliance>1.0</version.aopalliance>
     <version.ch.qos.cal10n>0.8.1</version.ch.qos.cal10n>
-    <version.ch.qos.logback>1.2.13</version.ch.qos.logback>
+    <version.ch.qos.logback>1.5.13</version.ch.qos.logback>
     <version.commons-beanutils>1.9.4</version.commons-beanutils>
     <version.commons-cli>1.4</version.commons-cli>
     <version.commons-codec>1.18.0</version.commons-codec>


### PR DESCRIPTION
The current logback-classic and logback-core Version: 1.2.13 is affected by [ https://github.com/advisories/GHSA-pr98-23f8-jwxv]
Updating logback-classic and logback-core to version 1.5.13 resolves the CVE