### PR TITLE
Upgrades jgit to 6.10, tomcat to 9.0.106 and spring-security-web to 5.7.14

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -268,6 +268,7 @@
     <version.org.springframework>5.3.39</version.org.springframework>
     <version.org.springframework.boot>2.7.18</version.org.springframework.boot>
     <version.org.springframework.osgi>1.2.1</version.org.springframework.osgi>
+    <version.org.springframework.security.web>5.7.14</version.org.springframework.security.web>
     <version.org.subethamail>1.2</version.org.subethamail>
     <version.org.subethamail.subethasmtp>3.1.6</version.org.subethamail.subethasmtp>
     <version.org.testcontainers>1.15.2</version.org.testcontainers>

--- a/pom.xml
+++ b/pom.xml
@@ -181,7 +181,7 @@
     <version.org.eclipse.jdt>3.18.0</version.org.eclipse.jdt>
     <!-- Jetty's version is aligned with CXF -->
     <version.org.eclipse.jetty>9.4.57.v20241219</version.org.eclipse.jetty>
-    <version.org.eclipse.jgit>v6.10.1.202505221210-r</version.org.eclipse.jgit>
+    <version.org.eclipse.jgit>6.10.1.202505221210-r</version.org.eclipse.jgit>
     <version.org.eclipse.sisu>0.3.5</version.org.eclipse.sisu>
     <version.org.eclipse.emf.gwt>2.9.0</version.org.eclipse.emf.gwt>
     <version.org.glassfish>3.1.2</version.org.glassfish>

--- a/pom.xml
+++ b/pom.xml
@@ -153,7 +153,7 @@
     <version.org.apache.neethi>3.1.1</version.org.apache.neethi>
     <version.org.apache.poi>5.4.1</version.org.apache.poi>
     <version.org.apache.sshd>2.9.2</version.org.apache.sshd>
-    <version.org.apache.tomcat>9.0.105</version.org.apache.tomcat>
+    <version.org.apache.tomcat>9.0.106</version.org.apache.tomcat>
     <version.org.apache.velocity>2.3</version.org.apache.velocity>
     <version.org.apache.xmlbeans>5.3.0</version.org.apache.xmlbeans>
     <version.org.apache.ws.xmlschema>2.2.5</version.org.apache.ws.xmlschema>

--- a/pom.xml
+++ b/pom.xml
@@ -181,7 +181,7 @@
     <version.org.eclipse.jdt>3.18.0</version.org.eclipse.jdt>
     <!-- Jetty's version is aligned with CXF -->
     <version.org.eclipse.jetty>9.4.57.v20241219</version.org.eclipse.jetty>
-    <version.org.eclipse.jgit>6.8.0.202311291450-r</version.org.eclipse.jgit>
+    <version.org.eclipse.jgit>v6.10.1.202505221210-r</version.org.eclipse.jgit>
     <version.org.eclipse.sisu>0.3.5</version.org.eclipse.sisu>
     <version.org.eclipse.emf.gwt>2.9.0</version.org.eclipse.emf.gwt>
     <version.org.glassfish>3.1.2</version.org.glassfish>


### PR DESCRIPTION
This PR updates jgit, tomcat and spring-security-web to fix vulnerabilities. 

Related PR: https://github.com/kiegroup/droolsjbpm-integration/pull/3085