### PR TITLE
[7.67.x-blue] Bump apache.commons.lang3 to 3.18.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
     <version.org.apache.commons.compress>1.27.1</version.org.apache.commons.compress>
     <version.org.apache.commons.csv>1.6</version.org.apache.commons.csv>
     <version.org.apache.commons.exec>1.3</version.org.apache.commons.exec>
-    <version.org.apache.commons.lang3>3.16.0</version.org.apache.commons.lang3>
+    <version.org.apache.commons.lang3>3.18.0</version.org.apache.commons.lang3>
     <version.org.apache.commons.math>2.1</version.org.apache.commons.math>
     <version.org.apache.commons.math3>3.4.1</version.org.apache.commons.math3>
     <version.org.apache.commons.pool2>2.4.2</version.org.apache.commons.pool2>


### PR DESCRIPTION
 Bump apache.commons.lang3 to 3.18.0 due to CVE-2025-48924