### PR TITLE
Upgrades artemis, cxf and commons-beanutils

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <version.aopalliance>1.0</version.aopalliance>
     <version.ch.qos.cal10n>0.8.1</version.ch.qos.cal10n>
     <version.ch.qos.logback>1.2.13</version.ch.qos.logback>
-    <version.commons-beanutils>1.9.4</version.commons-beanutils>
+    <version.commons-beanutils>1.11.0</version.commons-beanutils>
     <version.commons-cli>1.4</version.commons-cli>
     <version.commons-codec>1.18.0</version.commons-codec>
     <version.commons-collections>3.2.2</version.commons-collections>

--- a/pom.xml
+++ b/pom.xml
@@ -490,6 +490,7 @@
     <version.shade.plugin>3.2.4</version.shade.plugin>
 
     <version.lock-treatment-tool>^0.2.2</version.lock-treatment-tool>
+    <version.org.apache.activemq.artemis>2.38.0</version.org.apache.activemq.artemis>
   </properties>
 
   <repositories>
@@ -2241,14 +2242,43 @@
 
   <dependencyManagement>
     <dependencies>
-      <!-- dependencies from jboss-ip-bom -->
-      <!--
-        CONVENTIONS:
-        - Dependencies must be SORTED ALPHABETICALLY on groupId (other forms of sorting were found to be unclear and ambiguous).
-        - Do not declare <scope> (exception: import) or <optional>: a child module will declare scope/optional itself.
-        - Always extract the version as a property.
-        - A element's inner order is <groupId>, <artifactId>, [<type>,] [<classifier>,] <version> (following Aether proper)
-      -->
+      <!-- Version overrides to fix vulnerabilities -->
+      <dependency>
+        <groupId>org.apache.activemq</groupId>
+        <artifactId>artemis-jms-server</artifactId>
+        <version>${version.org.apache.activemq.artemis}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.apache.geronimo.specs</groupId>
+            <artifactId>geronimo-jms_2.0_spec</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.geronimo.specs</groupId>
+            <artifactId>geronimo-jta_1.1_spec</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.activemq</groupId>
+        <artifactId>artemis-jms-client</artifactId>
+        <version>${version.org.apache.activemq.artemis}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.jboss.spec.javax.jms</groupId>
+            <artifactId>jboss-jms-api_2.0_spec</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.geronimo.specs</groupId>
+            <artifactId>geronimo-json_1.0_spec</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <!-- Version overrides to fix vulnerabilities - end. -->
+
       <dependency>
         <groupId>org.kie</groupId>
         <artifactId>narayana-integration-bom</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -316,7 +316,7 @@
     <version.com.google.testing.compile>0.11</version.com.google.testing.compile>
     <version.org.antlr4>4.9.2</version.org.antlr4>
     <!-- CXF's version is aligned with Jetty -->
-    <version.org.apache.cxf>3.5.10</version.org.apache.cxf>
+    <version.org.apache.cxf>3.5.11</version.org.apache.cxf>
     <version.org.apache.camel>2.25.4</version.org.apache.camel>
     <version.org.codehaus.cargo>1.9.3</version.org.codehaus.cargo>
     <version.org.freemarker>2.3.30</version.org.freemarker>


### PR DESCRIPTION
Upgrades multiple dependencies. The version of artemis used is the last one that supports Java 11. 

Related PR: 
https://github.com/kiegroup/appformer/pull/1455
https://github.com/kiegroup/kie-wb-common/pull/3842