### PR TITLE
[7.67.x-blue] Upgrade strimzi-test-container to 0.113.0.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
     <version.io.micrometer>1.7.3</version.io.micrometer>
     <version.io.springfox>2.9.2</version.io.springfox>
     <version.io.smallrye.openapi.core>2.1.4</version.io.smallrye.openapi.core>
-    <version.io.strimzi.strimzi-test-container>0.106.0</version.io.strimzi.strimzi-test-container>
+    <version.io.strimzi.strimzi-test-container>0.113.0</version.io.strimzi.strimzi-test-container>
     <version.io.takari.maven.plugins.testing>2.9.2</version.io.takari.maven.plugins.testing>
     <version.io.undertow>2.2.38.Final</version.io.undertow>
     <version.jaxen>1.1.6</version.jaxen>


### PR DESCRIPTION
Update strimzi-test-container to support Kafka 3.7.2. Hopefully this fixes failures of pr checks in jbpm-work-items. 