### PR TITLE
[7.67.x-blue] upgrade xmlschema-core version from 2.2.5 to 2.3.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,7 @@
     <version.org.apache.tomcat>9.0.111</version.org.apache.tomcat>
     <version.org.apache.velocity>2.3</version.org.apache.velocity>
     <version.org.apache.xmlbeans>5.3.0</version.org.apache.xmlbeans>
-    <version.org.apache.ws.xmlschema>2.2.5</version.org.apache.ws.xmlschema>
+    <version.org.apache.ws.xmlschema>2.3.2</version.org.apache.ws.xmlschema>
     <version.org.apache.xmlgraphics.batik>1.18</version.org.apache.xmlgraphics.batik>
     <version.org.apache.xmlgraphics.commons>2.6</version.org.apache.xmlgraphics.commons>
     <version.org.assertj>3.14.0</version.org.assertj>


### PR DESCRIPTION
The current xmlschema-core  version 2.2.5, It needs to be updated to the latest version, 2.3.2, to update transitive dependencies. 

* <b>a pull request</b> please add comment: <b>Jenkins retest</b> (using <i>this</i> e.g. <b>Jenkins retest this</b> optional but no longer required)
 
* for a <b>full downstream build</b> 
  * for <b>jenkins</b> job: please add comment: <b>Jenkins run fdb</b>
  * for <b>github actions</b> job: add the label `run_fdb`
    
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>

* <b>for windows-specific os job</b> add the label `windows_check`
</details>

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>
