### PR TITLE
[7.67.x-blue] update undertow-core version to 2.2.38.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4912,6 +4912,12 @@
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-undertow</artifactId>
         <version>${version.org.jboss.resteasy}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>io.undertow</groupId>
+            <artifactId>undertow-core</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
     <version.io.smallrye.openapi.core>2.1.4</version.io.smallrye.openapi.core>
     <version.io.strimzi.strimzi-test-container>0.111.0</version.io.strimzi.strimzi-test-container>
     <version.io.takari.maven.plugins.testing>2.9.2</version.io.takari.maven.plugins.testing>
-    <version.io.undertow>2.3.20.SP4-redhat-00001</version.io.undertow>
+    <version.io.undertow>2.3.20.Final</version.io.undertow>
     <version.jaxen>1.1.6</version.jaxen>
     <version.org.igniterealtime.smack>4.1.9</version.org.igniterealtime.smack>
     <version.joda-time>2.9.7</version.joda-time>

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
     <version.io.smallrye.openapi.core>2.1.4</version.io.smallrye.openapi.core>
     <version.io.strimzi.strimzi-test-container>0.111.0</version.io.strimzi.strimzi-test-container>
     <version.io.takari.maven.plugins.testing>2.9.2</version.io.takari.maven.plugins.testing>
-    <version.io.undertow>2.2.38.Final</version.io.undertow>
+    <version.io.undertow>2.3.20.SP4-redhat-00001</version.io.undertow>
     <version.jaxen>1.1.6</version.jaxen>
     <version.org.igniterealtime.smack>4.1.9</version.org.igniterealtime.smack>
     <version.joda-time>2.9.7</version.joda-time>
@@ -4968,12 +4968,6 @@
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-undertow</artifactId>
         <version>${version.org.jboss.resteasy}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>io.undertow</groupId>
-            <artifactId>undertow-core</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
     <version.io.smallrye.openapi.core>2.1.4</version.io.smallrye.openapi.core>
     <version.io.strimzi.strimzi-test-container>0.111.0</version.io.strimzi.strimzi-test-container>
     <version.io.takari.maven.plugins.testing>2.9.2</version.io.takari.maven.plugins.testing>
-    <version.io.undertow>2.3.20.Final</version.io.undertow>
+    <version.io.undertow>2.2.39.Final</version.io.undertow>
     <version.jaxen>1.1.6</version.jaxen>
     <version.org.igniterealtime.smack>4.1.9</version.org.igniterealtime.smack>
     <version.joda-time>2.9.7</version.joda-time>


### PR DESCRIPTION
The **undertow-core** version 2.2.37, needs to be updated to the latest version, **2.2.38**, to update transitive dependencies.
Changes are required to exclude the incoming transitive dependencies for the same.

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>
