### PR TITLE
[7.67.x-blue] [DBACLD-189752] Bump ch.qos.logback:logback-core from 1.2.13 to 1.5.15

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     -->
     <version.aopalliance>1.0</version.aopalliance>
     <version.ch.qos.cal10n>0.8.1</version.ch.qos.cal10n>
-    <version.ch.qos.logback>1.3.15</version.ch.qos.logback>
+    <version.ch.qos.logback>1.5.15</version.ch.qos.logback>
     <version.commons-beanutils>1.11.0</version.commons-beanutils>
     <version.commons-cli>1.4</version.commons-cli>
     <version.commons-codec>1.18.0</version.commons-codec>
@@ -258,7 +258,8 @@
     <version.org.reflections>0.9.11</version.org.reflections>
     <!-- Avoid using scannotation in favor of its successor org.reflections -->
     <version.org.scannotation>1.0.3</version.org.scannotation>
-    <version.org.slf4j>1.7.30</version.org.slf4j>
+    <!-- DBACLD-189752  Upgraded slf4j version to 2.x to make it compatible with logback-classic -->
+    <version.org.slf4j>2.0.15</version.org.slf4j>
     <version.org.sonatype.aether>1.13.1</version.org.sonatype.aether>
     <version.org.sonatype.plexus.plexus-cipher>2.0</version.org.sonatype.plexus.plexus-cipher>
     <version.org.sonatype.plexus.plexus-sec-dispatcher>2.0</version.org.sonatype.plexus.plexus-sec-dispatcher>
@@ -6412,18 +6413,6 @@
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-classic</artifactId>
         <version>${version.ch.qos.logback}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-api</artifactId>
-        <version>1.7.32</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     -->
     <version.aopalliance>1.0</version.aopalliance>
     <version.ch.qos.cal10n>0.8.1</version.ch.qos.cal10n>
-    <version.ch.qos.logback>1.2.13</version.ch.qos.logback>
+    <version.ch.qos.logback>1.3.15</version.ch.qos.logback>
     <version.commons-beanutils>1.11.0</version.commons-beanutils>
     <version.commons-cli>1.4</version.commons-cli>
     <version.commons-codec>1.18.0</version.commons-codec>
@@ -6412,6 +6412,18 @@
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-classic</artifactId>
         <version>${version.ch.qos.logback}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>1.7.32</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
[DBACLD-189752] Bump ch.qos.logback:logback-core from 1.2.13 to 1.5.13

**Referenced Pull Requests**:
* [droolsjbpm-integration/pull/3093](https://github.com/kiegroup/droolsjbpm-integration/pull/3093)
* [kie-wb-common/pull/3846](https://github.com/kiegroup/kie-wb-common/pull/3846)