### PR TITLE
DBACLD-218294: [CVE][Critical]CVE-2026-27727-mchange-commons-java-0.2.15.redhat-00003.jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5165,6 +5165,14 @@
         <version>${version.org.quartz-scheduler}</version>
       </dependency>
 
+     
+      <dependency>
+        <groupId>com.mchange</groupId>
+        <artifactId>mchange-commons-java</artifactId>
+        <version>0.4.0</version>
+      </dependency>
+
+
       <dependency>
         <groupId>org.ocpsoft.prettytime</groupId>
         <artifactId>prettytime</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -255,6 +255,7 @@
     <version.org.powermock>2.0.7</version.org.powermock>
     <version.org.python>2.7.2</version.org.python>
     <version.org.quartz-scheduler>2.3.2</version.org.quartz-scheduler>
+    <version.com.mchange>0.4.0</version.com.mchange>
     <version.org.reflections>0.9.11</version.org.reflections>
     <!-- Avoid using scannotation in favor of its successor org.reflections -->
     <version.org.scannotation>1.0.3</version.org.scannotation>
@@ -5169,7 +5170,7 @@
       <dependency>
         <groupId>com.mchange</groupId>
         <artifactId>mchange-commons-java</artifactId>
-        <version>0.4.0</version>
+        <version>${version.com.mchange}</version>
       </dependency>
 
 


### PR DESCRIPTION
mchange-commons-java is updated to 0.4.0 which was previously 0.2.15 which is coming tranitively from below:

quartz-2.3.2.redhat-00007.jar → c3p0-0.9.5.4.jar → mchange-commons-java-0.2.15.redhat-00003.jar

quarkus-quartz-2.13.9.Final-redhat-00003.jar → quartz-2.3.2.redhat-00007.jar → mchange-commons-java-0.2.15.redhat-00003.jar

jbpm-spring-boot-starter-basic-7.67.2.Final-redhat-00042.jar → jbpm-spring-boot-autoconfiguration-7.67.2.Final-redhat-00042.jar → quartz-2.3.2.redhat-00007.jar → c3p0-0.9.5.4.jar → mchange-commons-java-0.2.15.redhat-00003.jar


dependency tree:

INFO] +- org.apache.commons:commons-lang3:jar:3.19.0:compile
[INFO] +- org.assertj:assertj-core:jar:3.14.0:test
[INFO] +- org.quartz-scheduler:quartz:jar:2.3.2:provided
[INFO] |  +- com.mchange:c3p0:jar:0.9.5.4:provided
[INFO] |  +- com.mchange:mchange-commons-java:jar:0.4.0:provided
[INFO] |  \- com.zaxxer:HikariCP-java7:jar:2.4.13:provided
[INFO] +- commons-io:commons-io:jar:2.20.0:test
[INFO] +- jakarta.xml.bind:jakarta.xml.bind-api:jar:2.3.3:provided