### PR TITLE
[7.67.x-blue] Fix CVEs CVE-2026-24734, CVE-2026-24733, CVE-2025-66614 by upgrading tomcat-embed-core to 9.0.115 

### DIFF
--- a/narayana-integration-bom/pom.xml
+++ b/narayana-integration-bom/pom.xml
@@ -24,7 +24,7 @@
     <!-- narayana dependencies for tomcat and kie server -->
     <version.org.jboss.narayana.tomcat>5.9.0.Final</version.org.jboss.narayana.tomcat>
     <!-- DBCP connection pooling for Narayana -->
-    <version.org.apache.tomcat.tomcat-dbcp>9.0.111</version.org.apache.tomcat.tomcat-dbcp>
+    <version.org.apache.tomcat.tomcat-dbcp>9.0.115</version.org.apache.tomcat.tomcat-dbcp>
 
     <version.org.jboss.transaction.spi>7.6.1.Final</version.org.jboss.transaction.spi>
     <version.jakarta.transaction-api>1.3.3</version.jakarta.transaction-api>

--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@
     <version.org.apache.neethi>3.1.1</version.org.apache.neethi>
     <version.org.apache.poi>5.4.1</version.org.apache.poi>
     <version.org.apache.sshd>2.13.2</version.org.apache.sshd>
-    <version.org.apache.tomcat>9.0.111</version.org.apache.tomcat>
+    <version.org.apache.tomcat>9.0.115</version.org.apache.tomcat>
     <version.org.apache.velocity>2.3</version.org.apache.velocity>
     <version.org.apache.xmlbeans>5.3.0</version.org.apache.xmlbeans>
     <version.org.apache.ws.xmlschema>2.3.2</version.org.apache.ws.xmlschema>


### PR DESCRIPTION
Upgraded tomcat-embed-core from 9.0.111 to 9.0.115 to fix the following high severity CVEs:

CVE-2026-24734
CVE-2026-24733
CVE-2025-66614