### PR TITLE
[7.67.x-blue] Update plexus utils version to 3.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,7 @@
     <version.org.codehaus.plexus.plexus-classworlds>2.6.0</version.org.codehaus.plexus.plexus-classworlds>
     <version.org.codehaus.plexus.plexus-containers>1.6</version.org.codehaus.plexus.plexus-containers>
     <version.org.codehaus.plexus.plexus-interpolation>1.26</version.org.codehaus.plexus.plexus-interpolation>
-    <version.org.codehaus.plexus.plexus-utils>3.3.1</version.org.codehaus.plexus.plexus-utils>
+    <version.org.codehaus.plexus.plexus-utils>3.6.1</version.org.codehaus.plexus.plexus-utils>
     <version.org.codehaus.woodstox>4.4.1</version.org.codehaus.woodstox>
     <version.org.easytesting.fest>2.0M6</version.org.easytesting.fest>
     <version.org.easymock>3.0</version.org.easymock>


### PR DESCRIPTION
Updating plexus utils version to 3.6.1 resolves the [CVE-2025-67030]
Linked pr : https://github.com/kiegroup/process-migration-service/pull/145