### PR TITLE
[7.67.x-blue] Update neethi version to 3.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@
     <version.org.apache.maven.archiver>3.3.0</version.org.apache.maven.archiver>
     <version.org.apache.maven.plugin-tools>3.4</version.org.apache.maven.plugin-tools>
     <version.org.apache.maven.wagon>3.5.1</version.org.apache.maven.wagon>
-    <version.org.apache.neethi>3.1.1</version.org.apache.neethi>
+    <version.org.apache.neethi>3.2.2</version.org.apache.neethi>
     <version.org.apache.poi>5.4.1</version.org.apache.poi>
     <version.org.apache.sshd>2.13.2</version.org.apache.sshd>
     <version.org.apache.tomcat>9.0.111</version.org.apache.tomcat>


### PR DESCRIPTION
Updating neethi version to 3.2.2 resolves the [CVE-2026-42403], [CVE-2026-42402], [CVE-2026-42404]